### PR TITLE
fix(): fix Crash happed when add space inside  numeric list

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/utils/AnnotatedStringExt.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/utils/AnnotatedStringExt.kt
@@ -78,9 +78,16 @@ internal fun AnnotatedString.Builder.append(
     richTextConfig: RichTextConfig,
 ): Int {
     var index = startIndex
+    if (index > text.length) {
+        index = text.length
+    }
+    var endIndex = index + richSpan.text.length
+    if (endIndex > text.length) {
+        endIndex = text.length
+    }
 
     withStyle(richSpan.spanStyle.merge(richSpan.style.spanStyle(richTextConfig))) {
-        val newText = text.substring(index, index + richSpan.text.length)
+        val newText = text.substring(index, endIndex)
         richSpan.text = newText
         richSpan.textRange = TextRange(index, index + richSpan.text.length)
         if (


### PR DESCRIPTION
fix crash of wrong start and end index in case of adding a new line  in numeric list style

[crash viedio.webm](https://github.com/MohamedRejeb/Compose-Rich-Editor/assets/28351422/51b8324c-864b-4c69-9f90-a3cb4825010a)

[after fixing issue.webm](https://github.com/MohamedRejeb/Compose-Rich-Editor/assets/28351422/1c85a3a9-9ebf-404d-b814-f4553aa90753)

