### PR TITLE
Fix: Added Support for Kotlin 1.9.20 and Compose Multiplatform 1.5.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,3 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 
 #iOS
 org.jetbrains.compose.experimental.uikit.enabled=true
-
-#Native
-kotlin.native.binary.memoryModel=experimental
-kotlin.native.cacheKind=none

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.0.2"
-kotlin = "1.9.10"
-compose = "1.5.1"
+kotlin = "1.9.20"
+compose = "1.5.10"
 dokka = "1.9.0"
 
 ksoup = "0.2.1"


### PR DESCRIPTION
The library failed to sync when it was added in a Kotlin 1.9.20 and Compose 1.5.10 Project
Upgrading both fixes the issue