### PR TITLE
Toolchain resolver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@ org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\=
 org.gradle.caching=true
 org.gradle.parallel=true
 
+org.gradle.java.installations.auto-detect=true
+org.gradle.java.installations.auto-download=true
+
 #Kotlin
 kotlin.code.style=official
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.1.0"
+agp = "8.2.2"
 kotlin = "1.9.21"
 compose = "1.5.11"
 dokka = "1.9.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,9 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+}
 
 rootProject.name = "compose-richeditor"
 


### PR DESCRIPTION
Gradle 8.x wants this apparently, I couldn't build without it and this was the solution suggested by the gradle error message.