### PR TITLE
Make it easier to override the default UriHandler

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichText.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichText.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -28,10 +29,10 @@ fun BasicRichText(
     softWrap: Boolean = true,
     maxLines: Int = Int.MAX_VALUE,
     minLines: Int = 1,
+    uriHandler: UriHandler = LocalUriHandler.current,
     inlineContent: Map<String, InlineTextContent> = mapOf()
 ) {
     val density = LocalDensity.current
-    val uriHandler = LocalUriHandler.current
     val pointerIcon = remember {
         mutableStateOf(PointerIcon.Default)
     }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material/RichText.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material/RichText.kt
@@ -1,12 +1,19 @@
 package com.mohamedrejeb.richeditor.ui.material
 
 import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.material.*
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
-import androidx.compose.ui.text.*
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.text.Paragraph
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -74,7 +81,8 @@ fun RichText(
     minLines: Int = 1,
     inlineContent: Map<String, InlineTextContent> = mapOf(),
     onTextLayout: (TextLayoutResult) -> Unit = {},
-    style: TextStyle = LocalTextStyle.current
+    style: TextStyle = LocalTextStyle.current,
+    uriHandler: UriHandler = LocalUriHandler.current,
 ) {
     val textColor = color.takeOrElse {
         style.color.takeOrElse {
@@ -105,6 +113,7 @@ fun RichText(
         softWrap = softWrap,
         maxLines = maxLines,
         minLines = minLines,
-        inlineContent = inlineContent
+        inlineContent = inlineContent,
+        uriHandler = uriHandler,
     )
 }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichText.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichText.kt
@@ -5,13 +5,11 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
-import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.text.Paragraph
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
@@ -79,7 +77,8 @@ fun RichText(
     maxLines: Int = Int.MAX_VALUE,
     inlineContent: Map<String, InlineTextContent> = mapOf(),
     onTextLayout: (TextLayoutResult) -> Unit = {},
-    style: TextStyle = LocalTextStyle.current
+    style: TextStyle = LocalTextStyle.current,
+    uriHandler: UriHandler = LocalUriHandler.current,
 ) {
     val textColor = color.takeOrElse {
         style.color.takeOrElse {
@@ -109,6 +108,7 @@ fun RichText(
         overflow = overflow,
         softWrap = softWrap,
         maxLines = maxLines,
-        inlineContent = inlineContent
+        inlineContent = inlineContent,
+        uriHandler = uriHandler,
     )
 }


### PR DESCRIPTION
You can rely on a composition local and override it that way, or you can pass it in as an argument.

Personally, if it is only for a single View, I find composition locals to be a bit cumbersome to override.

From the issue #145 open about this already I think others might as well. This would give people the option to override it either through the local, or just by passing in an argument.

However I can definitely understand the feeling that this is simply redundant to the composition local, so feel free to close this PR if you don't like it.