### PR TITLE
Return this for chaining

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -2304,7 +2304,5 @@ class RichTextState internal constructor(
                 richTextState
             }
         )
-
-
     }
 }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -2130,7 +2130,7 @@ class RichTextState internal constructor(
      *
      * @param text The text to update the [RichTextState] with.
      */
-    fun setText(text: String) {
+    fun setText(text: String): RichTextState {
         val textFieldValue =
             TextFieldValue(
                 text = text,
@@ -2140,6 +2140,7 @@ class RichTextState internal constructor(
         onTextFieldValueChange(
             newTextFieldValue = textFieldValue
         )
+        return this
     }
 
     /**
@@ -2147,9 +2148,10 @@ class RichTextState internal constructor(
      *
      * @param html The html to update the [RichTextState] with.
      */
-    fun setHtml(html: String) {
+    fun setHtml(html: String): RichTextState {
         val richParagraphList = RichTextStateHtmlParser.encode(html).richParagraphList
         updateRichParagraphList(richParagraphList)
+        return this
     }
 
     /**
@@ -2157,9 +2159,10 @@ class RichTextState internal constructor(
      *
      * @param markdown The markdown to update the [RichTextState] with.
      */
-    fun setMarkdown(markdown: String) {
+    fun setMarkdown(markdown: String): RichTextState {
         val richParagraphList = RichTextStateMarkdownParser.encode(markdown).richParagraphList
         updateRichParagraphList(richParagraphList)
+        return this
     }
 
     /**
@@ -2301,5 +2304,7 @@ class RichTextState internal constructor(
                 richTextState
             }
         )
+
+
     }
 }


### PR DESCRIPTION
Since we only have a default ctor, it would be nice to be able to construct, then set a text type, in one line:
```kotlin
remember { RichTextState().setMarkdown("asd") }
```