### PR TITLE
Export html with tags instead of styling when applicable

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/CssDecoder.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/CssDecoder.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.isUnspecified
-import androidx.compose.ui.unit.sp
 import com.mohamedrejeb.richeditor.utils.maxDecimals
 import kotlin.math.roundToInt
 
@@ -38,8 +37,19 @@ internal object CssDecoder {
      * @param spanStyle the span style to decode.
      * @return the decoded CSS style map.
      */
-    internal fun decodeSpanStyleToCssStyleMap(spanStyle: SpanStyle): Map<String, String> {
+    internal fun decodeSpanStyleToHtmlStylingFormat(spanStyle: SpanStyle): HtmlStylingFormat {
+        // TODO Manage
+        //        "mark" to MarkSpanStyle,
+        //        "small" to SmallSpanStyle,
+        //        "h1" to H1SPanStyle,
+        //        "h2" to H2SPanStyle,
+        //        "h3" to H3SPanStyle,
+        //        "h4" to H4SPanStyle,
+        //        "h5" to H5SPanStyle,
+        //        "h6" to H6SPanStyle,
+
         val cssStyleMap = mutableMapOf<String, String>()
+        val htmlTags = mutableListOf<String>()
 
         if (spanStyle.color.isSpecified) {
             cssStyleMap["color"] = decodeColorToCss(spanStyle.color)
@@ -50,10 +60,18 @@ internal object CssDecoder {
             }
         }
         spanStyle.fontWeight?.let { fontWeight ->
-            cssStyleMap["font-weight"] = decodeFontWeightToCss(fontWeight)
+            if (fontWeight == FontWeight.Bold) {
+                htmlTags.add("b") // TODO Check const
+            } else {
+                cssStyleMap["font-weight"] = decodeFontWeightToCss(fontWeight)
+            }
         }
         spanStyle.fontStyle?.let { fontStyle ->
-            cssStyleMap["font-style"] = decodeFontStyleToCss(fontStyle)
+            if (fontStyle == FontStyle.Italic) {
+                htmlTags.add("i") // TODO Check const
+            } else {
+                cssStyleMap["font-style"] = decodeFontStyleToCss(fontStyle)
+            }
         }
         if (spanStyle.letterSpacing.isSpecified) {
             decodeTextUnitToCss(spanStyle.letterSpacing)?.let { letterSpacing ->
@@ -61,19 +79,36 @@ internal object CssDecoder {
             }
         }
         spanStyle.baselineShift?.let { baselineShift ->
-            cssStyleMap["baseline-shift"] = decodeBaselineShiftToCss(baselineShift)
+            when (baselineShift) {
+                BaselineShift.Subscript -> htmlTags.add("sub") // TODO Check const
+                BaselineShift.Superscript -> htmlTags.add("sup") // TODO Check const
+                else -> cssStyleMap["baseline-shift"] = decodeBaselineShiftToCss(baselineShift)
+            }
         }
         if (spanStyle.background.isSpecified) {
             cssStyleMap["background"] = decodeColorToCss(spanStyle.background)
         }
         spanStyle.textDecoration?.let { textDecoration ->
-            cssStyleMap["text-decoration"] = decodeTextDecorationToCss(textDecoration)
+            when (textDecoration) {
+                TextDecoration.Underline -> htmlTags.add("u") // TODO Check const
+                TextDecoration.LineThrough -> htmlTags.add("s") // TODO Check const
+                TextDecoration.Underline + TextDecoration.LineThrough -> {
+                    htmlTags.add("u") // TODO Check const
+                    htmlTags.add("s") // TODO Check const
+                }
+
+                else -> cssStyleMap["text-decoration"] = decodeTextDecorationToCss(textDecoration)
+            }
+
         }
         spanStyle.shadow?.let { shadow ->
             cssStyleMap["text-shadow"] = decodeTextShadowToCss(shadow)
         }
 
-        return cssStyleMap
+        return HtmlStylingFormat(
+            htmlTags = htmlTags,
+            cssStyleMap = cssStyleMap,
+        )
     }
 
     /**
@@ -260,4 +295,8 @@ internal object CssDecoder {
         }
     }
 
+    data class HtmlStylingFormat(
+        val htmlTags: List<String>,
+        val cssStyleMap: Map<String, String>,
+    )
 }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/CssDecoder.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/CssDecoder.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.isUnspecified
+import com.mohamedrejeb.richeditor.parser.utils.MARK_BACKGROUND_COLOR
+import com.mohamedrejeb.richeditor.parser.utils.SMALL_FONT_SIZE
 import com.mohamedrejeb.richeditor.utils.maxDecimals
 import kotlin.math.roundToInt
 
@@ -38,16 +40,6 @@ internal object CssDecoder {
      * @return the decoded CSS style map.
      */
     internal fun decodeSpanStyleToHtmlStylingFormat(spanStyle: SpanStyle): HtmlStylingFormat {
-        // TODO Manage
-        //        "mark" to MarkSpanStyle,
-        //        "small" to SmallSpanStyle,
-        //        "h1" to H1SPanStyle,
-        //        "h2" to H2SPanStyle,
-        //        "h3" to H3SPanStyle,
-        //        "h4" to H4SPanStyle,
-        //        "h5" to H5SPanStyle,
-        //        "h6" to H6SPanStyle,
-
         val cssStyleMap = mutableMapOf<String, String>()
         val htmlTags = mutableListOf<String>()
 
@@ -55,20 +47,24 @@ internal object CssDecoder {
             cssStyleMap["color"] = decodeColorToCss(spanStyle.color)
         }
         if (spanStyle.fontSize.isSpecified) {
-            decodeTextUnitToCss(spanStyle.fontSize)?.let { fontSize ->
-                cssStyleMap["font-size"] = fontSize
+            if (spanStyle.fontSize == SMALL_FONT_SIZE) {
+                htmlTags.add("small")
+            } else {
+                decodeTextUnitToCss(spanStyle.fontSize)?.let { fontSize ->
+                    cssStyleMap["font-size"] = fontSize
+                }
             }
         }
         spanStyle.fontWeight?.let { fontWeight ->
             if (fontWeight == FontWeight.Bold) {
-                htmlTags.add("b") // TODO Check const
+                htmlTags.add("b")
             } else {
                 cssStyleMap["font-weight"] = decodeFontWeightToCss(fontWeight)
             }
         }
         spanStyle.fontStyle?.let { fontStyle ->
             if (fontStyle == FontStyle.Italic) {
-                htmlTags.add("i") // TODO Check const
+                htmlTags.add("i")
             } else {
                 cssStyleMap["font-style"] = decodeFontStyleToCss(fontStyle)
             }
@@ -80,21 +76,25 @@ internal object CssDecoder {
         }
         spanStyle.baselineShift?.let { baselineShift ->
             when (baselineShift) {
-                BaselineShift.Subscript -> htmlTags.add("sub") // TODO Check const
-                BaselineShift.Superscript -> htmlTags.add("sup") // TODO Check const
+                BaselineShift.Subscript -> htmlTags.add("sub")
+                BaselineShift.Superscript -> htmlTags.add("sup")
                 else -> cssStyleMap["baseline-shift"] = decodeBaselineShiftToCss(baselineShift)
             }
         }
         if (spanStyle.background.isSpecified) {
-            cssStyleMap["background"] = decodeColorToCss(spanStyle.background)
+            if (spanStyle.background == MARK_BACKGROUND_COLOR) {
+                htmlTags.add("mark")
+            } else {
+                cssStyleMap["background"] = decodeColorToCss(spanStyle.background)
+            }
         }
         spanStyle.textDecoration?.let { textDecoration ->
             when (textDecoration) {
-                TextDecoration.Underline -> htmlTags.add("u") // TODO Check const
-                TextDecoration.LineThrough -> htmlTags.add("s") // TODO Check const
+                TextDecoration.Underline -> htmlTags.add("u")
+                TextDecoration.LineThrough -> htmlTags.add("s")
                 TextDecoration.Underline + TextDecoration.LineThrough -> {
-                    htmlTags.add("u") // TODO Check const
-                    htmlTags.add("s") // TODO Check const
+                    htmlTags.add("u")
+                    htmlTags.add("s")
                 }
 
                 else -> cssStyleMap["text-decoration"] = decodeTextDecorationToCss(textDecoration)

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
@@ -213,7 +213,9 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
             val paragraphCss = CssDecoder.decodeCssStyleMap(paragraphCssMap)
 
             // Append paragraph opening tag
-            builder.append("<$paragraphTagName style=\"$paragraphCss\">")
+            builder.append("<$paragraphTagName")
+            if (paragraphCss.isNotBlank()) builder.append(" style=\"$paragraphCss\"")
+            builder.append(">")
 
             // Append paragraph children
             richParagraph.children.fastForEach { richSpan ->

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
@@ -254,8 +254,8 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
         }
 
         // Convert span style to CSS string
-        val spanCssMap = CssDecoder.decodeSpanStyleToCssStyleMap(richSpan.spanStyle)
-        val spanCss = CssDecoder.decodeCssStyleMap(spanCssMap)
+        val htmlStyleFormat = CssDecoder.decodeSpanStyleToHtmlStylingFormat(richSpan.spanStyle)
+        val spanCss = CssDecoder.decodeCssStyleMap(htmlStyleFormat.cssStyleMap)
 
         val isRequireOpeningTag = tagName != "span" || tagAttributes.isNotEmpty() || spanCss.isNotEmpty()
 
@@ -266,12 +266,20 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
             stringBuilder.append(">")
         }
 
+        htmlStyleFormat.htmlTags.forEach {
+            stringBuilder.append("<$it>")
+        }
+
         // Append text
         stringBuilder.append(KsoupEntities.encodeHtml(richSpan.text))
 
         // Append children
         richSpan.children.fastForEach { child ->
             stringBuilder.append(decodeRichSpanToHtml(child))
+        }
+
+        htmlStyleFormat.htmlTags.reversed().forEach {
+            stringBuilder.append("</$it>")
         }
 
         if (isRequireOpeningTag) {

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/utils/ElementsSpanStyle.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/utils/ElementsSpanStyle.kt
@@ -8,14 +8,17 @@ import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.em
 
+internal val MARK_BACKGROUND_COLOR = Color.Yellow
+internal val SMALL_FONT_SIZE = 0.8f.em
+
 internal val BoldSpanStyle = SpanStyle(fontWeight = FontWeight.Bold)
 internal val ItalicSpanStyle = SpanStyle(fontStyle = FontStyle.Italic)
 internal val UnderlineSpanStyle = SpanStyle(textDecoration = TextDecoration.Underline)
 internal val StrikethroughSpanStyle = SpanStyle(textDecoration = TextDecoration.LineThrough)
 internal val SubscriptSpanStyle = SpanStyle(baselineShift = BaselineShift.Subscript)
 internal val SuperscriptSpanStyle = SpanStyle(baselineShift = BaselineShift.Superscript)
-internal val MarkSpanStyle = SpanStyle(background = Color.Yellow)
-internal val SmallSpanStyle = SpanStyle(fontSize = 0.8f.em)
+internal val MarkSpanStyle = SpanStyle(background = MARK_BACKGROUND_COLOR)
+internal val SmallSpanStyle = SpanStyle(fontSize = SMALL_FONT_SIZE)
 internal val H1SPanStyle = SpanStyle(fontSize = 2.em, fontWeight = FontWeight.Bold)
 internal val H2SPanStyle = SpanStyle(fontSize = 1.5.em, fontWeight = FontWeight.Bold)
 internal val H3SPanStyle = SpanStyle(fontSize = 1.17.em, fontWeight = FontWeight.Bold)


### PR DESCRIPTION
This PR updates the formatting of the HTML output.

**Before:**
* Bold, italic ... were decoded as CSS styling, inline in the "span" tag. This will lose the semantic of these basics tags

**After:**
* When a matching tag (same as encode), we are replacing the styling by a dedicated tag.

This PR does not handle Header styles as Heading are paragraphs, not spans, and needs a special care.
⚠️ The HTML output is not the same as before, and can be considered as a breaking change
This may address this issue https://github.com/MohamedRejeb/Compose-Rich-Editor/issues/188 and our own use-case.
