### PR TITLE
Incorrect underline span to markdown

### DIFF
--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import coil3.util.DebugLogger
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.sample.common.components.RichTextStyleRow
 import com.mohamedrejeb.richeditor.sample.common.ui.theme.ComposeRichEditorTheme
@@ -33,6 +34,16 @@ fun RichEditorContent() {
             """
             <p><b>RichTextEditor</b> is a <i>composable</i> that allows you to edit <u>rich text</u> content.</p>
             """.trimIndent()
+        )
+    }
+
+    LaunchedEffect(basicRichTextState.annotatedString) {
+        val markdown = basicRichTextState.toMarkdown()
+        DebugLogger().log(
+            "RichEditorContent",
+            coil3.util.Logger.Level.Debug,
+            "BasicRichTextEditor markdown: $markdown",
+            null
         )
     }
 


### PR DESCRIPTION
Repro #314.


<img src="https://github.com/user-attachments/assets/c7ff59cd-abf9-4d0b-8427-4a294f413336" height="600">


```
2024-07-26 15:53:42.642 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: u
2024-07-26 15:53:42.820 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: un
2024-07-26 15:53:42.902 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: und
2024-07-26 15:53:43.135 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: unde
2024-07-26 15:53:43.215 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: under
2024-07-26 15:53:43.285 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: underl
2024-07-26 15:53:43.349 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: underli
2024-07-26 15:53:43.542 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: underlin
2024-07-26 15:53:43.620 14125-14125 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor markdown: underline
```