### PR TITLE
Incorrect plaintext line breaks

### DIFF
--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import coil3.util.DebugLogger
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.sample.common.components.RichTextStyleRow
 import com.mohamedrejeb.richeditor.sample.common.ui.theme.ComposeRichEditorTheme
@@ -33,6 +34,16 @@ fun RichEditorContent() {
             """
             <p><b>RichTextEditor</b> is a <i>composable</i> that allows you to edit <u>rich text</u> content.</p>
             """.trimIndent()
+        )
+    }
+
+    LaunchedEffect(basicRichTextState.annotatedString) {
+        val plaintext = basicRichTextState.annotatedString.toString()
+        DebugLogger().log(
+            "RichEditorContent",
+            coil3.util.Logger.Level.Debug,
+            "BasicRichTextEditor plaintext: $plaintext",
+            null
         )
     }
 


### PR DESCRIPTION
Repro #321.

<img src="https://github.com/user-attachments/assets/6b42035d-8352-408f-8635-b664a4e2d404" height="600">

```
2024-08-06 17:33:02.226 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: 
2024-08-06 17:33:04.993 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: t
2024-08-06 17:33:05.094 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: th
2024-08-06 17:33:05.175 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: thi
2024-08-06 17:33:05.289 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: this
2024-08-06 17:33:05.767 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: this 
2024-08-06 17:33:06.390 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: this i
2024-08-06 17:33:06.479 13600-13600 RichEditorContent       com.mohamedrejeb.richeditor.android  D  BasicRichTextEditor plaintext: this is
```