### PR TITLE
Add INTERNET permission to sample

### DIFF
--- a/sample/android/src/main/AndroidManifest.xml
+++ b/sample/android/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="false"
         android:supportsRtl="true"


### PR DESCRIPTION
## 👨‍💻 
Add `<img src="https://placehold.jp/3d4070/ffffff/1500x150.png">` to HTML editor, get a crash - since there's no `INTERNET` permission.

## 📜 

>  FATAL EXCEPTION: OkHttp Dispatcher
                                                                                                    Process: com.mohamedrejeb.richeditor.android, PID: 11205
                                                                                                    java.lang.SecurityException: Permission denied (missing INTERNET permission?)

## 🖼️ 
![Screenshot 2024-11-13 at 8 20 09](https://github.com/user-attachments/assets/f5c7fcd3-0c96-4624-84b8-720d024de6b1)
