### PR TITLE
Added `textChanges` `SharedFlow` to follow text changes

### DIFF
--- a/richeditor-compose/api/android/richeditor-compose.api
+++ b/richeditor-compose/api/android/richeditor-compose.api
@@ -155,6 +155,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun getSelectedLinkUrl ()Ljava/lang/String;
 	public final fun getSelection-d9O1mEE ()J
 	public final fun getSpanStyle-5zc-tL8 (J)Landroidx/compose/ui/text/SpanStyle;
+	public final fun getTextChanges ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun isCode ()Z
 	public final fun isCodeSpan ()Z
 	public final fun isLink ()Z

--- a/richeditor-compose/api/desktop/richeditor-compose.api
+++ b/richeditor-compose/api/desktop/richeditor-compose.api
@@ -155,6 +155,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun getSelectedLinkUrl ()Ljava/lang/String;
 	public final fun getSelection-d9O1mEE ()J
 	public final fun getSpanStyle-5zc-tL8 (J)Landroidx/compose/ui/text/SpanStyle;
+	public final fun getTextChanges ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun isCode ()Z
 	public final fun isCodeSpan ()Z
 	public final fun isLink ()Z

--- a/richeditor-compose/api/richeditor-compose.klib.api
+++ b/richeditor-compose/api/richeditor-compose.klib.api
@@ -165,6 +165,8 @@ final class com.mohamedrejeb.richeditor.model/RichTextState { // com.mohamedreje
         final fun <get-selectedLinkText>(): kotlin/String? // com.mohamedrejeb.richeditor.model/RichTextState.selectedLinkText.<get-selectedLinkText>|<get-selectedLinkText>(){}[0]
     final val selectedLinkUrl // com.mohamedrejeb.richeditor.model/RichTextState.selectedLinkUrl|{}selectedLinkUrl[0]
         final fun <get-selectedLinkUrl>(): kotlin/String? // com.mohamedrejeb.richeditor.model/RichTextState.selectedLinkUrl.<get-selectedLinkUrl>|<get-selectedLinkUrl>(){}[0]
+    final val textChanges // com.mohamedrejeb.richeditor.model/RichTextState.textChanges|{}textChanges[0]
+        final fun <get-textChanges>(): kotlinx.coroutines.flow/SharedFlow<com.mohamedrejeb.richeditor.model/RichTextState> // com.mohamedrejeb.richeditor.model/RichTextState.textChanges.<get-textChanges>|<get-textChanges>(){}[0]
 
     final var annotatedString // com.mohamedrejeb.richeditor.model/RichTextState.annotatedString|{}annotatedString[0]
         final fun <get-annotatedString>(): androidx.compose.ui.text/AnnotatedString // com.mohamedrejeb.richeditor.model/RichTextState.annotatedString.<get-annotatedString>|<get-annotatedString>(){}[0]

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
@@ -5,8 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -18,6 +17,7 @@ import com.mohamedrejeb.richeditor.ui.BasicRichTextEditor
 import com.mohamedrejeb.richeditor.ui.material3.OutlinedRichTextEditor
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
+import kotlinx.coroutines.*
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -27,6 +27,18 @@ fun RichEditorContent() {
     val basicRichTextState = rememberRichTextState()
     val richTextState = rememberRichTextState()
     val outlinedRichTextState = rememberRichTextState()
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        scope.launch {
+            println("Start collecting...")
+            outlinedRichTextState.textChanges.collect { state ->
+                println("Text changed!")
+                println(state.toText())
+            }
+            println("Collection finished!")
+        }
+    }
 
     LaunchedEffect(Unit) {
         richTextState.setHtml(

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/richeditor/RichEditorContent.kt
@@ -31,12 +31,10 @@ fun RichEditorContent() {
 
     LaunchedEffect(Unit) {
         scope.launch {
-            println("Start collecting...")
             outlinedRichTextState.textChanges.collect { state ->
                 println("Text changed!")
                 println(state.toText())
             }
-            println("Collection finished!")
         }
     }
 


### PR DESCRIPTION
An alternative to #431, I think I like this one better?

Allow users to hook into text changes as they happen. Because it's a flow, it can be more easily filtered for specific types of changes in the future.