### PR TITLE
added support for nested lists

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/DefaultParagraph.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/DefaultParagraph.kt
@@ -18,7 +18,7 @@ internal class DefaultParagraph : ParagraphType {
     override val startRichSpan: RichSpan =
         RichSpan(paragraph = RichParagraph(type = this))
 
-    override fun getNextParagraphType(): ParagraphType =
+    override fun getNextParagraphType(nestedLevel: ListNestedLevel?): ParagraphType =
         DefaultParagraph()
 
     override fun copy(): ParagraphType =

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ListNestedLevel.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ListNestedLevel.kt
@@ -1,0 +1,40 @@
+package com.mohamedrejeb.richeditor.paragraph.type
+
+public enum class ListNestedLevel(
+    internal val indentMultiplier: Float,
+    internal val number: Int // the Number Must be the same as Level
+) {
+    LEVEL_1(indentMultiplier = 1f, number = 1),
+    LEVEL_2(indentMultiplier = 2f, number = 2),
+    LEVEL_3(indentMultiplier = 3f, number = 3);
+
+    internal fun getNextOrMax(): ListNestedLevel {
+        return when (this) {
+            LEVEL_1 -> LEVEL_2
+            LEVEL_2 -> LEVEL_3
+            LEVEL_3 -> LEVEL_3
+        }
+    }
+
+    internal fun getPreviousOrMin(): ListNestedLevel {
+        return when (this) {
+            LEVEL_1 -> LEVEL_1
+            LEVEL_2 -> LEVEL_1
+            LEVEL_3 -> LEVEL_2
+        }
+    }
+
+
+    internal companion object {
+        val maxNestedLevel = LEVEL_3
+
+        fun getByNumber(number: Int): ListNestedLevel? {
+            return when (number) {
+                1 -> LEVEL_1
+                2 -> LEVEL_2
+                3 -> LEVEL_3
+                else -> null
+            }
+        }
+    }
+}

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
@@ -16,7 +16,8 @@ internal class OrderedList(
     number: Int,
     initialIndent: Int = DefaultListIndent,
     startTextSpanStyle: SpanStyle = SpanStyle(),
-    startTextWidth: TextUnit = 0.sp
+    startTextWidth: TextUnit = 0.sp,
+    initialNestedLevel: ListNestedLevel = ListNestedLevel.LEVEL_1
 ) : ParagraphType, ConfigurableStartTextWidth {
 
     var number = number
@@ -39,6 +40,12 @@ internal class OrderedList(
 
     private var indent = initialIndent
 
+    var nestedLevel = initialNestedLevel
+        set(value) {
+            field = value
+            startRichSpan = getNewStartRichSpan(startRichSpan.textRange)
+        }
+
     private var style: ParagraphStyle =
         getNewParagraphStyle()
 
@@ -54,8 +61,8 @@ internal class OrderedList(
     private fun getNewParagraphStyle() =
         ParagraphStyle(
             textIndent = TextIndent(
-                firstLine = (indent - startTextWidth.value).sp,
-                restLine = indent.sp
+                firstLine = ((indent * nestedLevel.indentMultiplier) - startTextWidth.value).sp,
+                restLine = (indent * nestedLevel.indentMultiplier).sp
             )
         )
 
@@ -77,12 +84,13 @@ internal class OrderedList(
         )
     }
 
-    override fun getNextParagraphType(): ParagraphType =
+    override fun getNextParagraphType(nestedLevel: ListNestedLevel?): ParagraphType =
         OrderedList(
             number = number + 1,
             initialIndent = indent,
             startTextSpanStyle = startTextSpanStyle,
-            startTextWidth = startTextWidth
+            startTextWidth = startTextWidth,
+            initialNestedLevel = nestedLevel ?: this.nestedLevel
         )
 
     override fun copy(): ParagraphType =
@@ -90,7 +98,8 @@ internal class OrderedList(
             number = number,
             initialIndent = indent,
             startTextSpanStyle = startTextSpanStyle,
-            startTextWidth = startTextWidth
+            startTextWidth = startTextWidth,
+            initialNestedLevel = nestedLevel
         )
 
     override fun equals(other: Any?): Boolean {

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ParagraphType.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ParagraphType.kt
@@ -10,7 +10,7 @@ internal interface ParagraphType {
 
     val startRichSpan: RichSpan
 
-    fun getNextParagraphType(): ParagraphType
+    fun getNextParagraphType(nestedLevel: ListNestedLevel? = null): ParagraphType
 
     fun copy(): ParagraphType
 

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
@@ -13,6 +13,7 @@ import com.mohamedrejeb.richeditor.paragraph.RichParagraph
 internal class UnorderedList(
     initialIndent: Int = DefaultListIndent,
     startTextWidth: TextUnit = 0.sp,
+    initialNestedLevel: ListNestedLevel = ListNestedLevel.LEVEL_1
 ): ParagraphType, ConfigurableStartTextWidth {
 
     override var startTextWidth: TextUnit = startTextWidth
@@ -22,6 +23,8 @@ internal class UnorderedList(
         }
 
     private var indent = initialIndent
+
+    public var nestedLevel = initialNestedLevel
 
     private var style: ParagraphStyle =
         getParagraphStyle()
@@ -38,8 +41,8 @@ internal class UnorderedList(
     private fun getParagraphStyle() =
         ParagraphStyle(
             textIndent = TextIndent(
-                firstLine = indent.sp,
-                restLine = (indent + startTextWidth.value).sp
+                firstLine = (indent * nestedLevel.indentMultiplier).sp,
+                restLine = ((indent * nestedLevel.indentMultiplier) + startTextWidth.value).sp
             )
         )
 
@@ -50,16 +53,18 @@ internal class UnorderedList(
             text = "• ",
         )
 
-    override fun getNextParagraphType(): ParagraphType =
+    override fun getNextParagraphType(nestedLevel: ListNestedLevel?): ParagraphType =
         UnorderedList(
             initialIndent = indent,
-            startTextWidth = startTextWidth
+            startTextWidth = startTextWidth,
+            initialNestedLevel = nestedLevel ?: this.nestedLevel
         )
 
     override fun copy(): ParagraphType =
         UnorderedList(
             initialIndent = indent,
-            startTextWidth = startTextWidth
+            startTextWidth = startTextWidth,
+            initialNestedLevel = nestedLevel
         )
 
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
### Add Full Support for Nested Lists in RichText Editor

This pull request introduces comprehensive support for nested lists, including both `OrderedList` and `UnorderedLists`.

#### Key Features:
- **RichTextState Support**: Added core functionality to handle nested lists.
- **Markdown Support**: Correct parsing and rendering for nested lists in Markdown.
- **HTML Support**: Proper rendering for nested lists in HTML phrasing.

---

#### Nested List Behavior:
Nesting levels are managed using an enum (`ListNestedLevel`) that supports three levels:
1. Default indentation
2. One level deeper
3. Two levels deeper

##### Example:  
![Screenshot_20241220_190832_com mohamedrejeb richeditor android](https://github.com/user-attachments/assets/635ebecf-0e63-4353-bf72-18fc4b0e8862)


You can control nesting levels programmatically with these public functions:
- `RichTextState.increaseListNestedLevel()`
- `RichTextState.decreaseListNestedLevel()`

---

#### Testing
To keep this PR focused, sample updates were excluded. You can test the functionality by adding the following snippet to `RichTextStyleRow`:

```kotlin
item {
    RichTextStyleButton(
        onClick = {
            state.decreaseListNestedLevel()
        },
        icon = Icons.AutoMirrored.Outlined.FormatIndentDecrease,
    )
}

item {
    RichTextStyleButton(
        onClick = {
            state.increaseListNestedLevel()
        },
        icon = Icons.AutoMirrored.Outlined.FormatIndentIncrease,
    )
}
```

---

This implementation provides a streamlined approach to nested list management, enhancing both Markdown and HTML capabilities. Feedback and suggestions are welcome! 🎉