### PR TITLE
Issue #471 - Surface URI Click Callbacks for HTML Links

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichText.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichText.kt
@@ -33,6 +33,7 @@ public fun BasicRichText(
     minLines: Int = 1,
     inlineContent: Map<String, InlineTextContent> = mapOf(),
     imageLoader: ImageLoader = LocalImageLoader.current,
+    onUriClick: ((String) -> Unit)? = null,
 ) {
     val density = LocalDensity.current
     val uriHandler = LocalUriHandler.current
@@ -73,7 +74,7 @@ public fun BasicRichText(
                         onTap = { offset ->
                             state.getLinkByOffset(offset)?.let { url ->
                                 try {
-                                    uriHandler.openUri(url)
+                                    onUriClick?.let { it(url) } ?: uriHandler.openUri(url)
                                 } catch (e: Exception) {
                                     e.printStackTrace()
                                 }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichText.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichText.kt
@@ -79,6 +79,7 @@ public fun RichText(
     onTextLayout: (TextLayoutResult) -> Unit = {},
     style: TextStyle = LocalTextStyle.current,
     imageLoader: ImageLoader = LocalImageLoader.current,
+    onUriClick: ((String) -> Unit)? = null,
 ) {
     val textColor = color.takeOrElse {
         style.color.takeOrElse {
@@ -110,5 +111,6 @@ public fun RichText(
         maxLines = maxLines,
         inlineContent = inlineContent,
         imageLoader = imageLoader,
+        onUriClick = onUriClick
     )
 }


### PR DESCRIPTION
Issue Link -> https://github.com/MohamedRejeb/compose-rich-editor/issues/471

**PR Description :** 
Added Callbacks for the Html link clicks so that it would be useful to handle clicks and tracking events etc, configurable to the dev

**Code Changes**
Added Callbacks for both `BasicRichText` and `RichText` to handle callback clicks