### PR TITLE
fix: Do not change text color of disabled RichTextEditor

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/OutlinedRichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/OutlinedRichTextEditor.kt
@@ -115,7 +115,7 @@ public fun OutlinedRichTextEditor(
 ) {
     // If color is not provided via the text style, use content color as a default
     val textColor = textStyle.color.takeOrElse {
-        colors.textColor(enabled).value
+        colors.textColor().value
     }
     val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
 

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichTextEditor.kt
@@ -118,7 +118,7 @@ public fun RichTextEditor(
 ) {
     // If color is not provided via the text style, use content color as a default
     val textColor = textStyle.color.takeOrElse {
-        colors.textColor(enabled).value
+        colors.textColor().value
     }
     val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
 

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichTextEditorDefaults.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/RichTextEditorDefaults.kt
@@ -816,8 +816,8 @@ public class RichTextEditorColors internal constructor(
     }
 
     @Composable
-    internal fun textColor(enabled: Boolean): State<Color> {
-        return rememberUpdatedState(if (enabled) textColor else disabledTextColor)
+    internal fun textColor(): State<Color> {
+        return rememberUpdatedState(textColor)
     }
 
     @Composable


### PR DESCRIPTION
**ISSUE:**
When setting `RichTextEditor`'s `enabled = false`, text color changes to disabled color, which in theory makes sense. However, if we set a text that has some color specified, only the part with default color will change to disabled color, and the rest of the text that has "rich" color, will remain the same. 

**SOLUTION:**
In this PR, I removed the logic that sets color to disabled color. 
Ideally, we would apply alpha value to whole text and then we would see disabled state for the whole text with alpha value applied to each color.
Unfortunately, I do not have enough knowledge  of this project to figure full solution out yet.

@MohamedRejeb I am not able to add a reviewer, so tagging you directly. Thank you.
