### PR TITLE
feat: Add ability to clear color span range

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -459,6 +459,22 @@ public class RichTextState internal constructor(
     }
 
     /**
+     * Clear color [SpanStyle]s for current selection.
+     */
+    public fun clearSelectionColorSpans() {
+        annotatedString
+            .subSequence(selection)
+            .spanStyles
+            .filter { it.item.color.isSpecified }
+            .forEach {
+                val spanStyle = SpanStyle(color = it.item.color)
+                toRemoveSpanStyle = toRemoveSpanStyle.customMerge(spanStyle)
+                toAddSpanStyle = toAddSpanStyle.unmerge(spanStyle)
+                if (!selection.collapsed) applyRichSpanStyleToSelectedText()
+            }
+    }
+
+    /**
      * Add new [SpanStyle] to the [currentSpanStyle]
      *
      * Example: You can add Bold FontWeight by passing:

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -446,10 +446,16 @@ public class RichTextState internal constructor(
      * @see [removeSpanStyle]
      */
     public fun toggleSpanStyle(spanStyle: SpanStyle) {
-        if (currentSpanStyle.isSpecifiedFieldsEquals(spanStyle))
-            removeSpanStyle(spanStyle)
-        else
-            addSpanStyle(spanStyle)
+        if (spanStyle.isUnspecifiedColorSpan()) {
+            val modifiedSpan = currentSpanStyle.copy(color = Color.Unspecified)
+            removeSpanStyle(currentSpanStyle)
+            addSpanStyle(modifiedSpan)
+        } else {
+            if (currentSpanStyle.isSpecifiedFieldsEquals(spanStyle))
+                removeSpanStyle(spanStyle)
+            else
+                addSpanStyle(spanStyle)
+        }
     }
 
     /**
@@ -3276,4 +3282,8 @@ public class RichTextState internal constructor(
             }
         )
     }
+}
+
+private fun SpanStyle.isUnspecifiedColorSpan(): Boolean {
+    return this == SpanStyle(color = Color.Unspecified)
 }


### PR DESCRIPTION
1. We had a case where we needed to remove color span instead of toggling. Setting `Color.Unspecified` did not work. I had to pass in exact Span with color to clear. A cleaner way could be to pass in `Color.Unspecified`, which would just remove current color span. First commit addresses that case.

2. When text has multiple color spans and I want to select whole text and remove all color spans - it is currently impossible.  Second commit added ability to clear all color spans for current selection.

I cant add reviewers, so tagging you directly @MohamedRejeb 