### PR TITLE
feat: Allow setting text range when setting text to RichTextState

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -3086,11 +3086,14 @@ public class RichTextState internal constructor(
      *
      * @param text The text to update the [RichTextState] with.
      */
-    public fun setText(text: String): RichTextState {
+    public fun setText(
+        text: String,
+        selection: TextRange = TextRange(text.length),
+    ): RichTextState {
         val textFieldValue =
             TextFieldValue(
                 text = text,
-                selection = TextRange(text.length),
+                selection = selection,
             )
 
         onTextFieldValueChange(


### PR DESCRIPTION
**ISSUE:**
When setting text, selection is automatically set to the end of text. This behavior does not work well when we want to set `RichTextField` to disabled to simply display a rich text, because it shows last half of the text as preview.

**SOLUTION:**
As a solution we can allow setting text range while setting text to `RichTextState`.

I cant add reviewers, so tagging you directly @MohamedRejeb 