### PR TITLE
Fixed startTextWidth calculating for paragraph types

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -3258,7 +3258,7 @@ public class RichTextState internal constructor(
                         )
                     val distanceSp =
                         with(density) {
-                            (end - start).toSp()
+                            (end - start).absoluteValue.toSp()
                         }
 
                     if (paragraphType.startTextWidth != distanceSp) {


### PR DESCRIPTION
When the layout is set to RTL, the distance value becomes negative, which causes the following problem:

before:
![before](https://github.com/user-attachments/assets/920b2c31-9780-4205-9343-8e3abd0fe5f3)

after:
![after](https://github.com/user-attachments/assets/641de485-55a7-4ddd-a6fe-ba77d627e736)
