### PR TITLE
Fix indent for orderedlist paragraph

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
@@ -90,8 +90,8 @@ internal class OrderedList private constructor(
     private fun getNewParagraphStyle() =
         ParagraphStyle(
             textIndent = TextIndent(
-                firstLine = ((indent * level) - startTextWidth.value).sp,
-                restLine = (indent * level).sp
+                firstLine = (indent * level).sp,
+                restLine = ((indent * level) + startTextWidth.value).sp
             )
         )
 


### PR DESCRIPTION
### Issue:
Indent for ordered list is not working as expected.

Using a listIndent or orderedListIndent less than the prefix's width results in the number always being cutoff from the editor.

Using Sample's default MarkdownEditorContent implementation with `richTextState.config.orderedListIndent = 40`
<img width="1102" height="205" alt="Screenshot 2026-01-23 at 3 10 46 p m" src="https://github.com/user-attachments/assets/f3ebcc04-fc8f-47f5-a347-abe3f50542fd" />

### Solution:

This adds the startTextWidth to the level multiplier for the restLine, instead of removing it from the firstline which always removed the width of the number in the list.

### Before and After Screenshot
Using `richTextState.config.orderedListIndent = 0` 
Before:
<img width="700" alt="Screenshot 2026-01-23 at 2 47 08 p m" src="https://github.com/user-attachments/assets/06ff9e78-1d5d-460c-ac34-73c3d9a2da53" />

After:
<img width="700" alt="Screenshot 2026-01-23 at 2 49 26 p m" src="https://github.com/user-attachments/assets/885faa3d-5ba2-4356-b6c3-466ba352976b" />

