### PR TITLE
Fix StringIndexOutOfBoundsException for Rich Text Editor

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/MarkdownUtils.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/MarkdownUtils.kt
@@ -19,14 +19,13 @@ internal fun encodeMarkdownToRichText(
     onHtmlTag: (tag: String) -> Unit,
     onHtmlBlock: (html: String) -> Unit,
 ) {
-    val markdownText = correctMarkdownText(markdown)
 
     val parser = MarkdownParser(GFMFlavourDescriptor())
-    val tree = parser.buildMarkdownTreeFromString(markdownText)
+    val tree = parser.buildMarkdownTreeFromString(markdown)
     tree.children.fastForEach { node ->
         encodeMarkdownNodeToRichText(
             node = node,
-            markdown = markdownText,
+            markdown = markdown,
             onOpenNode = onOpenNode,
             onCloseNode = onCloseNode,
             onText = onText,

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
@@ -108,8 +108,11 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
             }
         }
 
+        // Correct the markdown text first so we can use it in callbacks
+        val correctedMarkdown = correctMarkdownText(input)
+
         encodeMarkdownToRichText(
-            markdown = input,
+            markdown = correctedMarkdown,
             onText = { text ->
                 onText(text)
             },
@@ -152,7 +155,7 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
                         currentRichSpan = null
                     }
                 } else if (node.type != MarkdownTokenTypes.EOL) {
-                    val richSpanStyle = encodeMarkdownElementToRichSpanStyle(node, input)
+                    val richSpanStyle = encodeMarkdownElementToRichSpanStyle(node, correctedMarkdown)
 
                     if (richParagraphList.isEmpty())
                         richParagraphList.add(RichParagraph())
@@ -201,7 +204,7 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
                     node.type == GFMTokenTypes.GFM_AUTOLINK ||
                     node.type == MarkdownTokenTypes.CODE_LINE
                 ) {
-                    onText(node.getTextInNode(input).toString())
+                    onText(node.getTextInNode(correctedMarkdown).toString())
                 }
             },
             onCloseNode = { node ->

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/MarkdownUtilsTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/MarkdownUtilsTest.kt
@@ -1,7 +1,10 @@
 package com.mohamedrejeb.richeditor.parser.markdown
 
+import com.mohamedrejeb.richeditor.model.RichTextState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
 
 class MarkdownUtilsTest {
 
@@ -80,6 +83,69 @@ class MarkdownUtilsTest {
             expectedOutput,
             correctMarkdownText(markdownInput)
         )
+    }
+
+    @Test
+    fun testDeepNestedList20Levels() {
+        val input = buildString {
+            repeat(20) { level ->
+                append("  ".repeat(level))  // 2-space indent per level
+                appendLine("- Item ${level + 1}")
+            }
+        }.trimEnd()
+
+        val output = correctMarkdownText(input)
+
+        assertTrue(
+            output.length >= input.length,
+            "Lost ${input.length - output.length} characters"
+        )
+    }
+
+    @Test
+    fun testDeepNestedListWithFormatting() {
+        val input = buildString {
+            repeat(20) { level ->
+                append("  ".repeat(level))
+                appendLine("- Item ${level + 1} **bold** *italic*")
+            }
+        }.trimEnd()
+
+        val output = correctMarkdownText(input)
+        assertTrue(output.length >= input.length)
+    }
+
+
+    @Test
+    fun testParseDeepNestedListDoesNotCrash() {
+        // This should not throw StringIndexOutOfBoundsException
+        val markdown = buildString {
+            repeat(20) { level ->
+                append("  ".repeat(level))
+                appendLine("- Item ${level + 1} **bold** [link](url)")
+            }
+        }.trimEnd()
+
+        // This calls correctMarkdownText(), builds AST, then calls getTextInNode()
+        val encoded = RichTextStateMarkdownParser.encode(markdown)
+        assertTrue(encoded.richParagraphList.isNotEmpty())
+    }
+
+    @Test
+    fun testNestedListWithoutCrash() {
+        // From the production crash report
+        val message = buildString {
+            repeat(20) { i ->
+                append("- Item $i\n")
+                append("  - Nested $i\n")
+            }
+            append("**Bold at end** and [link](http://test.com)")
+        }
+
+        // Should not throw StringIndexOutOfBoundsException
+        val state = RichTextState()
+        state.setMarkdown(message)
+        assertNotNull(state.annotatedString.text)
     }
 
 }


### PR DESCRIPTION
## 📃 Description
The bug is in `correctMarkdownText()` function in `MarkdownUtils.kt`. The function modifies the input text but produces **shorter output** than expected, causing AST offset mismatches.

### The Problem Flow

1. **Original text** is passed to markdown parser → AST built with offsets based on original length
2. **`correctMarkdownText()`** processes text → output is SHORTER than input (spaces lost)
3. **`getTextInNode()`** uses AST offsets on corrected text → **CRASH** (offset exceeds length)

### Before 
<img width="1288" height="803" alt="Screenshot 2026-02-05 at 23 46 28" src="https://github.com/user-attachments/assets/844a7d75-8b5d-4f81-8a7e-4516dc761878" />
<img width="1290" height="801" alt="Screenshot 2026-02-05 at 23 46 04" src="https://github.com/user-attachments/assets/4e502fbf-bf97-45d7-8cd6-b6c072a2f5b5" />

### After

<img width="1284" height="432" alt="Screenshot 2026-02-06 at 00 16 46" src="https://github.com/user-attachments/assets/7ceda847-a6c9-4f7d-9741-3e6a351a4278" />