### PR TITLE
Expose textFieldValue and onTextFieldValueChange as public API

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -57,7 +57,7 @@ public class RichTextState internal constructor(
 
     internal val richParagraphList = mutableStateListOf<RichParagraph>()
     internal var visualTransformation: VisualTransformation by mutableStateOf(VisualTransformation.None)
-    internal var textFieldValue by mutableStateOf(TextFieldValue())
+    public var textFieldValue by mutableStateOf(TextFieldValue())
         private set
 
     internal val inlineContentMap = mutableStateMapOf<String, InlineTextContent>()
@@ -1525,7 +1525,7 @@ public class RichTextState internal constructor(
      *
      * @param newTextFieldValue the new text field value.
      */
-    internal fun onTextFieldValueChange(newTextFieldValue: TextFieldValue) {
+    public fun onTextFieldValueChange(newTextFieldValue: TextFieldValue) {
         tempTextFieldValue = newTextFieldValue
 
         if (tempTextFieldValue.text.length > textFieldValue.text.length)


### PR DESCRIPTION
## Summary

- Make `textFieldValue` public (was `internal`) on `RichTextState`
- Make `onTextFieldValueChange` public (was `internal`) on `RichTextState`

## Motivation

When building mention/hashtag systems on top of `BasicRichTextEditor`, consumers need synchronous interception of text changes to protect mention tokens from partial deletion. For example, pressing backspace at the end of `@John Doe` should remove the entire mention in one go, not just the last character.

This behavior mirrors Compose Text 2's `InputTransformation` but for the old `BasicTextField(value, onValueChange)` API that `BasicRichTextEditor` wraps.

The typical pattern is to wrap `BasicTextField` directly with a custom `onValueChange` that inspects the change, modifies it if needed, then forwards to `state.onTextFieldValueChange()`:

```kotlin
BasicTextField(
    value = state.textFieldValue,
    onValueChange = { newValue ->
        val corrected = interceptMentionDeletion(state.textFieldValue, newValue)
        state.onTextFieldValueChange(corrected ?: newValue)
    },
    visualTransformation = state.visualTransformation,
)
```

Without public access to these members, consumers must use reflection which is fragile across library versions and breaks with R8/ProGuard optimizations.

## Changes

2 lines changed in `RichTextState.kt`:
- Line 60: `internal var textFieldValue` → `public var textFieldValue`
- Line 1528: `internal fun onTextFieldValueChange` → `public fun onTextFieldValueChange`

No behavioral changes. No new APIs. Just visibility.