### PR TITLE
Fix HTML parsing for line breaks within paragraphs

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -904,6 +904,7 @@ public class RichTextState internal constructor(
             if (selection.collapsed) {
                 val paragraph = getRichParagraphByTextIndex(selection.min - 1) ?: return
                 paragraph.paragraphStyle = paragraph.paragraphStyle.merge(paragraphStyle)
+                clearLineBreakContinuations(paragraph)
             }
             // If the selection is not collapsed, we add the paragraph style to all the paragraphs in the selection
             else {
@@ -911,6 +912,7 @@ public class RichTextState internal constructor(
                 if (paragraphs.isEmpty()) return
                 paragraphs.fastForEach {
                     it.paragraphStyle = it.paragraphStyle.merge(paragraphStyle)
+                    clearLineBreakContinuations(it)
                 }
             }
             // We update the annotated string to reflect the changes
@@ -940,6 +942,7 @@ public class RichTextState internal constructor(
             if (selection.collapsed) {
                 val paragraph = getRichParagraphByTextIndex(selection.min - 1) ?: return
                 paragraph.paragraphStyle = paragraph.paragraphStyle.unmerge(paragraphStyle)
+                clearLineBreakContinuations(paragraph)
             }
             // If the selection is not collapsed, we remove the paragraph style from all the paragraphs in the selection
             else {
@@ -947,6 +950,7 @@ public class RichTextState internal constructor(
                 if (paragraphs.isEmpty()) return
                 paragraphs.fastForEach {
                     it.paragraphStyle = it.paragraphStyle.unmerge(paragraphStyle)
+                    clearLineBreakContinuations(it)
                 }
             }
             // We update the annotated string to reflect the changes
@@ -1518,6 +1522,9 @@ public class RichTextState internal constructor(
             (firstNonEmptyChildIndex ?: selection.min).coerceAtLeast(0)
 
         paragraph.type = newType
+
+        // A paragraph change means this and its trailing <br> continuations are independent now
+        clearLineBreakContinuations(paragraph)
 
         // If the paragraph type start text length didn't change, we don't need to update the text field value
         if (paragraphOldStartTextLength == newType.startText.length)
@@ -3263,6 +3270,23 @@ public class RichTextState internal constructor(
         val richSpanList = getRichSpanListByTextRange(textRange)
 
         return richSpanList.getCommonStyle() ?: RichSpanStyle.DefaultSpanStyle
+    }
+
+    /**
+     * Clears [RichParagraph.isFromLineBreak] on the given paragraph and all
+     * consecutive trailing paragraphs that have `isFromLineBreak = true`.
+     *
+     * This ensures that when a paragraph's style or type changes, its `<br>`
+     * continuations become independent paragraphs in the HTML output.
+     */
+    private fun clearLineBreakContinuations(paragraph: RichParagraph) {
+        paragraph.isFromLineBreak = false
+        val index = richParagraphList.indexOf(paragraph)
+        if (index < 0) return
+        for (i in (index + 1)..richParagraphList.lastIndex) {
+            if (!richParagraphList[i].isFromLineBreak) break
+            richParagraphList[i].isFromLineBreak = false
+        }
     }
 
     /**

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
@@ -18,6 +18,12 @@ internal class RichParagraph(
     val children: MutableList<RichSpan> = mutableListOf(),
     var paragraphStyle: ParagraphStyle = DefaultParagraphStyle,
     var type: ParagraphType = DefaultParagraph(),
+    /**
+     * When true, this paragraph was created from a `<br>` tag during HTML parsing
+     * and should be joined with the previous paragraph using `<br>` in HTML output
+     * rather than being wrapped in its own `<p>` tag.
+     */
+    var isFromLineBreak: Boolean = false,
 ) {
 
     @OptIn(ExperimentalRichTextApi::class)

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
@@ -160,6 +160,12 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                     newRichParagraph.paragraphStyle = newRichParagraph.paragraphStyle.merge(cssParagraphStyle)
                     newRichParagraph.type = paragraphType
 
+                    // A block element (<p>, <h1>, etc.) opening on a blank paragraph
+                    // from a <br> should not carry the linebreak flag
+                    if (isCurrentRichParagraphBlank && newRichParagraph.isFromLineBreak && name != "li") {
+                        newRichParagraph.isFromLineBreak = false
+                    }
+
                     if (!isCurrentRichParagraphBlank) {
                         stringBuilder.append(' ')
 
@@ -196,9 +202,12 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
 
                     val newParagraph =
                         if (richParagraphList.isEmpty())
-                            RichParagraph()
+                            RichParagraph(isFromLineBreak = true)
                         else
-                            RichParagraph(paragraphStyle = richParagraphList.last().paragraphStyle)
+                            RichParagraph(
+                                paragraphStyle = richParagraphList.last().paragraphStyle,
+                                isFromLineBreak = true,
+                            )
 
                     richParagraphList.add(newParagraph)
 
@@ -443,22 +452,38 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                     if (paragraphGroupTagName == "ol" || paragraphGroupTagName == "ul") "li"
                     else "p"
 
-                // Create paragraph css
-                val paragraphCssMap = CssDecoder.decodeParagraphStyleToCssStyleMap(richParagraph.paragraphStyle)
-                val paragraphCss = CssDecoder.decodeCssStyleMap(paragraphCssMap)
+                // If this paragraph came from a <br>, emit <br> + content inline
+                // without opening a new <p> tag (the previous <p> is still open)
+                if (richParagraph.isFromLineBreak && index > 0) {
+                    builder.append("<$BrElement>")
+                    richParagraph.children.fastForEach { richSpan ->
+                        builder.append(decodeRichSpanToHtml(richSpan))
+                    }
+                } else {
+                    // Create paragraph css
+                    val paragraphCssMap = CssDecoder.decodeParagraphStyleToCssStyleMap(richParagraph.paragraphStyle)
+                    val paragraphCss = CssDecoder.decodeCssStyleMap(paragraphCssMap)
 
-                // Append paragraph opening tag
-                builder.append("<$paragraphTagName")
-                if (paragraphCss.isNotBlank()) builder.append(" style=\"$paragraphCss\"")
-                builder.append(">")
+                    // Append paragraph opening tag
+                    builder.append("<$paragraphTagName")
+                    if (paragraphCss.isNotBlank()) builder.append(" style=\"$paragraphCss\"")
+                    builder.append(">")
 
-                // Append paragraph children
-                richParagraph.children.fastForEach { richSpan ->
-                    builder.append(decodeRichSpanToHtml(richSpan))
+                    // Append paragraph children
+                    richParagraph.children.fastForEach { richSpan ->
+                        builder.append(decodeRichSpanToHtml(richSpan))
+                    }
                 }
 
-                // Append paragraph closing tag
-                builder.append("</$paragraphTagName>")
+                // Check if the next paragraph is also a <br> continuation — if so, don't close yet
+                val nextParagraph = richTextState.richParagraphList.getOrNull(index + 1)
+                val nextIsLineBreakContinuation = nextParagraph != null &&
+                    nextParagraph.isFromLineBreak &&
+                    !nextParagraph.isEmpty()
+
+                if (!nextIsLineBreakContinuation) {
+                    builder.append("</$paragraphTagName>")
+                }
             }
 
             // Save last paragraph group tag name

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserBugTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserBugTest.kt
@@ -1,8 +1,11 @@
 package com.mohamedrejeb.richeditor.parser.html
 
+import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichSpanStyle
 import com.mohamedrejeb.richeditor.model.RichTextState
@@ -226,9 +229,6 @@ class RichTextStateHtmlParserBugTest {
     // #583: \n rendered as empty <p></p> instead of <br> in HTML output
     // ========================================================================
 
-    // TODO: <br> within a paragraph creates separate RichParagraph objects during parsing.
-    //  The HTML decoder then outputs each as a separate <p> instead of using <br> within one <p>.
-    @Ignore
     @Test
     fun testIssue583_newlinesWithinParagraphExportAsBr() {
         // When a user types newlines within a paragraph (not Enter to create new paragraph),
@@ -261,6 +261,106 @@ class RichTextStateHtmlParserBugTest {
             pCount,
             "#583: Single paragraph with <br> should export as 1 <p>, not $pCount. HTML: '$html'"
         )
+    }
+
+    @Test
+    fun testIssue583_brRoundTrip() {
+        // <br> inside a paragraph should survive round-trip
+        val input = "<p>Line one<br>Line two<br>Line three</p>"
+        val state = RichTextState()
+        state.setHtml(input)
+
+        val html = state.toHtml()
+        assertEquals(input, html, "#583: <br> round-trip should be exact")
+    }
+
+    @Test
+    fun testIssue583_lineBreakFlagClearedOnParagraphStyleChange() {
+        // Changing paragraph style (e.g. alignment) on a <br> paragraph
+        // should clear isFromLineBreak so it exports as its own <p>
+        val state = RichTextState()
+        state.setHtml("<p>Line one<br>Line two</p>")
+
+        // Verify initial state: line two should be isFromLineBreak
+        assertTrue(state.richParagraphList[1].isFromLineBreak, "Line two should be from linebreak initially")
+
+        // Select "Line two" and change alignment
+        val lineTwoStart = state.annotatedString.text.indexOf("Line two")
+        state.selection = TextRange(lineTwoStart, lineTwoStart + "Line two".length)
+        state.addParagraphStyle(ParagraphStyle(textAlign = TextAlign.Center))
+
+        // isFromLineBreak should now be cleared
+        assertFalse(state.richParagraphList[1].isFromLineBreak, "isFromLineBreak should be cleared after paragraph style change")
+
+        // HTML should now have two <p> tags
+        val html = state.toHtml()
+        val pCount = "<p".toRegex().findAll(html).count()
+        assertEquals(2, pCount, "Should have 2 <p> tags after style change. HTML: '$html'")
+    }
+
+    @Test
+    fun testIssue583_parentStyleChangeClearsTrailingContinuations() {
+        // Changing the FIRST paragraph's style should clear isFromLineBreak
+        // on all trailing continuation paragraphs
+        val state = RichTextState()
+        state.setHtml("<p>Line one<br>Line two<br>Line three</p>")
+
+        assertEquals(3, state.richParagraphList.size)
+        assertFalse(state.richParagraphList[0].isFromLineBreak)
+        assertTrue(state.richParagraphList[1].isFromLineBreak)
+        assertTrue(state.richParagraphList[2].isFromLineBreak)
+
+        // Select "Line one" (the parent paragraph) and change alignment
+        val lineOneStart = state.annotatedString.text.indexOf("Line one")
+        state.selection = TextRange(lineOneStart, lineOneStart + "Line one".length)
+        state.addParagraphStyle(ParagraphStyle(textAlign = TextAlign.Center))
+
+        // All trailing continuations should be cleared
+        assertFalse(state.richParagraphList[1].isFromLineBreak, "Line two should no longer be from linebreak")
+        assertFalse(state.richParagraphList[2].isFromLineBreak, "Line three should no longer be from linebreak")
+
+        // HTML should have 3 separate <p> tags
+        val html = state.toHtml()
+        val pCount = "<p".toRegex().findAll(html).count()
+        assertEquals(3, pCount, "Should have 3 <p> tags after parent style change. HTML: '$html'")
+    }
+
+    @Test
+    fun testIssue583_lineBreakFlagClearedOnListToggle() {
+        // Converting a <br> paragraph to a list should clear isFromLineBreak
+        val state = RichTextState()
+        state.setHtml("<p>Line one<br>Line two</p>")
+
+        assertTrue(state.richParagraphList[1].isFromLineBreak)
+
+        // Select "Line two" and toggle ordered list
+        val lineTwoStart = state.annotatedString.text.indexOf("Line two")
+        state.selection = TextRange(lineTwoStart, lineTwoStart + "Line two".length)
+        state.toggleOrderedList()
+
+        assertFalse(state.richParagraphList[1].isFromLineBreak, "isFromLineBreak should be cleared after list toggle")
+    }
+
+    @Test
+    fun testIssue583_lineBreakFlagPreservedOnSpanStyleChange() {
+        // Changing SPAN style (bold, italic) should NOT clear isFromLineBreak
+        // because span styles don't change the paragraph structure
+        val state = RichTextState()
+        state.setHtml("<p>Line one<br>Line two</p>")
+
+        assertTrue(state.richParagraphList[1].isFromLineBreak)
+
+        // Select "Line two" and make it bold
+        val lineTwoStart = state.annotatedString.text.indexOf("Line two")
+        state.selection = TextRange(lineTwoStart, lineTwoStart + "Line two".length)
+        state.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
+
+        // isFromLineBreak should still be true — bold doesn't change paragraph structure
+        assertTrue(state.richParagraphList[1].isFromLineBreak, "isFromLineBreak should survive span style changes")
+
+        // HTML should still use <br>
+        val html = state.toHtml()
+        assertTrue(html.contains("<br>"), "Should still use <br>. HTML: '$html'")
     }
 
     // ========================================================================


### PR DESCRIPTION
Fixes: #583 

- Resolved incorrect handling of `<br>` tags by preserving line breaks within a single `<p>` instead of creating multiple tags.
- Introduced `isFromLineBreak` flag in `RichParagraph` to identify paragraphs originating from line breaks.
- Updated HTML encoder and decoder logic to respect `isFromLineBreak` behavior.
- Added tests for verifying correct `<br>` handling in HTML parsing and rendering.