### PR TITLE
Fix `<br>` handling in inline elements and preserve parent span styles

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
@@ -226,6 +226,7 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                             val cssSpanStyle = CssEncoder.parseCssStyleMapToSpanStyle(cssStyleMap)
                             val tagSpanStyle = htmlElementsSpanStyleEncodeMap[name]
                             val tagWithCssSpanStyle = cssSpanStyle.customMerge(tagSpanStyle)
+                            val richSpanStyle = encodeHtmlElementToRichSpanStyle(name, attributes)
 
                             val newRichSpan = RichSpan(
                                 children = mutableListOf(),
@@ -233,7 +234,8 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                                 parent = currentRichSpan,
                                 text = "",
                                 textRange = TextRange.Zero,
-                                spanStyle = tagWithCssSpanStyle
+                                spanStyle = tagWithCssSpanStyle,
+                                richSpanStyle = richSpanStyle,
                             )
 
                             if (currentRichSpan == null) {

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserBugTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserBugTest.kt
@@ -185,9 +185,6 @@ class RichTextStateHtmlParserBugTest {
     // #586: <br> breaks <a> tag
     // ========================================================================
 
-    // TODO: <br> inside an inline element (<a>, <strong>, etc.) creates a new RichParagraph
-    //  which loses the parent span's RichSpanStyle (Link in this case).
-    @Ignore
     @Test
     fun testIssue586_brInsideLinkPreservesLink() {
         // Input: <a href="https://example.com"><br>Text<br></a>


### PR DESCRIPTION
Fixes: #586 

- Resolved issue where `<br>` inside inline elements (e.g., `<a>`, `<strong>`) created new paragraphs and lost parent span styles.
- Enabled test for verifying correct handling of `<br>` within links.