### PR TITLE
feat: add mentions/triggers with atomic token spans (#45, #252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,52 @@ val markdown = richTextState.toMarkdown()
 
 Check out Compose Rich Editor's [full documentation](https://mohamedrejeb.github.io/compose-rich-editor/) for more details.
 
+## Mentions, Hashtags, Slash Commands (Triggers)
+
+> Experimental — gated by `@ExperimentalRichTextApi`.
+
+A generic trigger system lets you add `@mentions`, `#hashtags`, `/commands` or any
+single-character trigger. A trigger activates a query mode; when the user selects a
+suggestion, an atomic `Token` span is inserted. Tokens are deleted, selected, and
+skipped as a single unit, and they round-trip through both HTML and Markdown.
+
+Register triggers on the state and observe `activeTriggerQuery`:
+
+```kotlin
+import com.mohamedrejeb.richeditor.model.trigger.Trigger
+import com.mohamedrejeb.richeditor.ui.material3.TriggerSuggestions
+
+val state = rememberRichTextState()
+
+LaunchedEffect(Unit) {
+    state.registerTrigger(Trigger(id = "mention", char = '@'))
+    state.registerTrigger(Trigger(id = "hashtag", char = '#'))
+}
+
+Box {
+    RichTextEditor(state = state)
+
+    // Drop in the built-in popup, or roll your own using state.activeTriggerQuery.
+    TriggerSuggestions(
+        state = state,
+        triggerId = "mention",
+        suggestions = { query -> users.filter { it.handle.contains(query) } },
+        onSelect = { user ->
+            RichSpanStyle.Token(
+                triggerId = "mention",
+                id = user.id,
+                label = "@${user.handle}",
+            )
+        },
+        item = { user -> Text(user.handle) },
+    )
+}
+```
+
+Tokens serialize as `<span data-trigger="mention" data-id="u123">@mohamed</span>` in HTML
+and `[@mohamed](trigger:mention:u123)` in Markdown, so content round-trips even in viewers
+that don't know about triggers.
+
 ## Web live demo
 You can try out the web demo [here](https://compose-richeditor.netlify.app/).
 

--- a/richeditor-compose/api/android/richeditor-compose.api
+++ b/richeditor-compose/api/android/richeditor-compose.api
@@ -36,6 +36,7 @@ public abstract interface class com/mohamedrejeb/richeditor/model/RichSpanStyle 
 	public static synthetic fun drawCustomStyle-zdrCDHg$default (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;Landroidx/compose/ui/graphics/drawscope/DrawScope;Landroidx/compose/ui/text/TextLayoutResult;JLcom/mohamedrejeb/richeditor/model/RichTextConfig;FFILjava/lang/Object;)V
 	public abstract fun getAcceptNewTextInTheEdges ()Z
 	public abstract fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
+	public fun isAtomic ()Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Code : com/mohamedrejeb/richeditor/model/RichSpanStyle {
@@ -48,6 +49,7 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Code : com/mo
 	public fun getAcceptNewTextInTheEdges ()Z
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
+	public fun isAtomic ()Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Companion {
@@ -62,12 +64,14 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Default : com
 	public fun getAcceptNewTextInTheEdges ()Z
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
+	public fun isAtomic ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$DefaultImpls {
 	public static fun appendCustomContent (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;Landroidx/compose/ui/text/AnnotatedString$Builder;Lcom/mohamedrejeb/richeditor/model/RichTextState;)Landroidx/compose/ui/text/AnnotatedString$Builder;
 	public static synthetic fun drawCustomStyle-zdrCDHg$default (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;Landroidx/compose/ui/graphics/drawscope/DrawScope;Landroidx/compose/ui/text/TextLayoutResult;JLcom/mohamedrejeb/richeditor/model/RichTextConfig;FFILjava/lang/Object;)V
+	public static fun isAtomic (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;)Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Image : com/mohamedrejeb/richeditor/model/RichSpanStyle {
@@ -84,6 +88,7 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Image : com/m
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public final fun getWidth-XSAIIZE ()J
 	public fun hashCode ()I
+	public fun isAtomic ()Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Link : com/mohamedrejeb/richeditor/model/RichSpanStyle {
@@ -96,6 +101,23 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Link : com/mo
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun isAtomic ()Z
+}
+
+public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Token : com/mohamedrejeb/richeditor/model/RichSpanStyle {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun appendCustomContent (Landroidx/compose/ui/text/AnnotatedString$Builder;Lcom/mohamedrejeb/richeditor/model/RichTextState;)Landroidx/compose/ui/text/AnnotatedString$Builder;
+	public fun drawCustomStyle-zdrCDHg (Landroidx/compose/ui/graphics/drawscope/DrawScope;Landroidx/compose/ui/text/TextLayoutResult;JLcom/mohamedrejeb/richeditor/model/RichTextConfig;FF)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAcceptNewTextInTheEdges ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
+	public final fun getTriggerId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isAtomic ()Z
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
@@ -144,6 +166,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun addTextAfterSelection (Ljava/lang/String;)V
 	public final fun addTextAtIndex (ILjava/lang/String;)V
 	public final fun addUnorderedList ()V
+	public final fun cancelActiveTrigger ()V
 	public final fun clear ()V
 	public final fun clearRichSpans ()V
 	public final fun clearRichSpans-5zc-tL8 (J)V
@@ -151,6 +174,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun clearSpanStyles-5zc-tL8 (J)V
 	public final fun copy ()Lcom/mohamedrejeb/richeditor/model/RichTextState;
 	public final fun decreaseListLevel ()V
+	public final fun getActiveTriggerQuery ()Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;
 	public final fun getAnnotatedString ()Landroidx/compose/ui/text/AnnotatedString;
 	public final fun getCanDecreaseListLevel ()Z
 	public final fun getCanIncreaseListLevel ()Z
@@ -165,11 +189,13 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun getSelectedLinkUrl ()Ljava/lang/String;
 	public final fun getSelection-d9O1mEE ()J
 	public final fun getSpanStyle-5zc-tL8 (J)Landroidx/compose/ui/text/SpanStyle;
+	public final fun getTriggers ()Ljava/util/List;
 	public final fun increaseListLevel ()V
 	public final fun insertHtml (Ljava/lang/String;I)V
 	public final fun insertHtmlAfterSelection (Ljava/lang/String;)V
 	public final fun insertMarkdown (Ljava/lang/String;I)V
 	public final fun insertMarkdownAfterSelection (Ljava/lang/String;)V
+	public final fun insertToken (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun isCode ()Z
 	public final fun isCodeSpan ()Z
 	public final fun isLink ()Z
@@ -178,6 +204,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun isRichSpan (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;)Z
 	public final fun isRichSpan (Lkotlin/reflect/KClass;)Z
 	public final fun isUnorderedList ()Z
+	public final fun registerTrigger (Lcom/mohamedrejeb/richeditor/model/trigger/Trigger;)V
 	public final fun removeCode ()V
 	public final fun removeCodeSpan ()V
 	public final fun removeLink ()V
@@ -212,6 +239,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun toggleRichSpan (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;)V
 	public final fun toggleSpanStyle (Landroidx/compose/ui/text/SpanStyle;)V
 	public final fun toggleUnorderedList ()V
+	public final fun unregisterTrigger (Ljava/lang/String;)V
 	public final fun updateLink (Ljava/lang/String;)V
 }
 
@@ -234,6 +262,44 @@ public final class com/mohamedrejeb/richeditor/model/TextPaddingValues {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHorizontal-XSAIIZE ()J
 	public final fun getVertical-XSAIIZE ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/mohamedrejeb/richeditor/model/trigger/Trigger {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;CLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function6;Ljava/util/Set;ZI)V
+	public synthetic fun <init> (Ljava/lang/String;CLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function6;Ljava/util/Set;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChar ()C
+	public final fun getDrawStyle ()Lkotlin/jvm/functions/Function6;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxQueryLength ()I
+	public final fun getRequireWordBoundary ()Z
+	public final fun getStopChars ()Ljava/util/Set;
+	public final fun getStyle ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/mohamedrejeb/richeditor/model/trigger/TriggerKt {
+	public static final fun getDefaultTriggerStopChars ()Ljava/util/Set;
+}
+
+public final class com/mohamedrejeb/richeditor/model/trigger/TriggerQuery {
+	public static final field $stable I
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLandroidx/compose/ui/geometry/Rect;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-d9O1mEE ()J
+	public final fun component4 ()Landroidx/compose/ui/geometry/Rect;
+	public final fun copy-YmzfRxQ (Ljava/lang/String;Ljava/lang/String;JLandroidx/compose/ui/geometry/Rect;)Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;
+	public static synthetic fun copy-YmzfRxQ$default (Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;Ljava/lang/String;Ljava/lang/String;JLandroidx/compose/ui/geometry/Rect;ILjava/lang/Object;)Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaretRect ()Landroidx/compose/ui/geometry/Rect;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getRange-d9O1mEE ()J
+	public final fun getTriggerId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -391,6 +457,10 @@ public final class com/mohamedrejeb/richeditor/ui/material3/RichTextEditorKt {
 
 public final class com/mohamedrejeb/richeditor/ui/material3/RichTextKt {
 	public static final fun RichText-a0LXGaU (Lcom/mohamedrejeb/richeditor/model/RichTextState;Landroidx/compose/ui/Modifier;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;IJIZIILjava/util/Map;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Lcom/mohamedrejeb/richeditor/model/ImageLoader;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class com/mohamedrejeb/richeditor/ui/material3/TriggerSuggestionsKt {
+	public static final fun TriggerSuggestions-aF7bR5A (Lcom/mohamedrejeb/richeditor/model/RichTextState;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;FJJJLandroidx/compose/ui/graphics/Shape;ILkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/mohamedrejeb/richeditor/utils/FloatUtilsKt {

--- a/richeditor-compose/api/desktop/richeditor-compose.api
+++ b/richeditor-compose/api/desktop/richeditor-compose.api
@@ -36,6 +36,7 @@ public abstract interface class com/mohamedrejeb/richeditor/model/RichSpanStyle 
 	public static synthetic fun drawCustomStyle-zdrCDHg$default (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;Landroidx/compose/ui/graphics/drawscope/DrawScope;Landroidx/compose/ui/text/TextLayoutResult;JLcom/mohamedrejeb/richeditor/model/RichTextConfig;FFILjava/lang/Object;)V
 	public abstract fun getAcceptNewTextInTheEdges ()Z
 	public abstract fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
+	public fun isAtomic ()Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Code : com/mohamedrejeb/richeditor/model/RichSpanStyle {
@@ -48,6 +49,7 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Code : com/mo
 	public fun getAcceptNewTextInTheEdges ()Z
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
+	public fun isAtomic ()Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Companion {
@@ -62,12 +64,14 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Default : com
 	public fun getAcceptNewTextInTheEdges ()Z
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
+	public fun isAtomic ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$DefaultImpls {
 	public static fun appendCustomContent (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;Landroidx/compose/ui/text/AnnotatedString$Builder;Lcom/mohamedrejeb/richeditor/model/RichTextState;)Landroidx/compose/ui/text/AnnotatedString$Builder;
 	public static synthetic fun drawCustomStyle-zdrCDHg$default (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;Landroidx/compose/ui/graphics/drawscope/DrawScope;Landroidx/compose/ui/text/TextLayoutResult;JLcom/mohamedrejeb/richeditor/model/RichTextConfig;FFILjava/lang/Object;)V
+	public static fun isAtomic (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;)Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Image : com/mohamedrejeb/richeditor/model/RichSpanStyle {
@@ -84,6 +88,7 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Image : com/m
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public final fun getWidth-XSAIIZE ()J
 	public fun hashCode ()I
+	public fun isAtomic ()Z
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Link : com/mohamedrejeb/richeditor/model/RichSpanStyle {
@@ -96,6 +101,23 @@ public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Link : com/mo
 	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun isAtomic ()Z
+}
+
+public final class com/mohamedrejeb/richeditor/model/RichSpanStyle$Token : com/mohamedrejeb/richeditor/model/RichSpanStyle {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun appendCustomContent (Landroidx/compose/ui/text/AnnotatedString$Builder;Lcom/mohamedrejeb/richeditor/model/RichTextState;)Landroidx/compose/ui/text/AnnotatedString$Builder;
+	public fun drawCustomStyle-zdrCDHg (Landroidx/compose/ui/graphics/drawscope/DrawScope;Landroidx/compose/ui/text/TextLayoutResult;JLcom/mohamedrejeb/richeditor/model/RichTextConfig;FF)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAcceptNewTextInTheEdges ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun getSpanStyle ()Lkotlin/jvm/functions/Function1;
+	public final fun getTriggerId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isAtomic ()Z
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
@@ -144,6 +166,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun addTextAfterSelection (Ljava/lang/String;)V
 	public final fun addTextAtIndex (ILjava/lang/String;)V
 	public final fun addUnorderedList ()V
+	public final fun cancelActiveTrigger ()V
 	public final fun clear ()V
 	public final fun clearRichSpans ()V
 	public final fun clearRichSpans-5zc-tL8 (J)V
@@ -151,6 +174,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun clearSpanStyles-5zc-tL8 (J)V
 	public final fun copy ()Lcom/mohamedrejeb/richeditor/model/RichTextState;
 	public final fun decreaseListLevel ()V
+	public final fun getActiveTriggerQuery ()Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;
 	public final fun getAnnotatedString ()Landroidx/compose/ui/text/AnnotatedString;
 	public final fun getCanDecreaseListLevel ()Z
 	public final fun getCanIncreaseListLevel ()Z
@@ -165,11 +189,13 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun getSelectedLinkUrl ()Ljava/lang/String;
 	public final fun getSelection-d9O1mEE ()J
 	public final fun getSpanStyle-5zc-tL8 (J)Landroidx/compose/ui/text/SpanStyle;
+	public final fun getTriggers ()Ljava/util/List;
 	public final fun increaseListLevel ()V
 	public final fun insertHtml (Ljava/lang/String;I)V
 	public final fun insertHtmlAfterSelection (Ljava/lang/String;)V
 	public final fun insertMarkdown (Ljava/lang/String;I)V
 	public final fun insertMarkdownAfterSelection (Ljava/lang/String;)V
+	public final fun insertToken (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun isCode ()Z
 	public final fun isCodeSpan ()Z
 	public final fun isLink ()Z
@@ -178,6 +204,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun isRichSpan (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;)Z
 	public final fun isRichSpan (Lkotlin/reflect/KClass;)Z
 	public final fun isUnorderedList ()Z
+	public final fun registerTrigger (Lcom/mohamedrejeb/richeditor/model/trigger/Trigger;)V
 	public final fun removeCode ()V
 	public final fun removeCodeSpan ()V
 	public final fun removeLink ()V
@@ -212,6 +239,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextState {
 	public final fun toggleRichSpan (Lcom/mohamedrejeb/richeditor/model/RichSpanStyle;)V
 	public final fun toggleSpanStyle (Landroidx/compose/ui/text/SpanStyle;)V
 	public final fun toggleUnorderedList ()V
+	public final fun unregisterTrigger (Ljava/lang/String;)V
 	public final fun updateLink (Ljava/lang/String;)V
 }
 
@@ -234,6 +262,44 @@ public final class com/mohamedrejeb/richeditor/model/TextPaddingValues {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHorizontal-XSAIIZE ()J
 	public final fun getVertical-XSAIIZE ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/mohamedrejeb/richeditor/model/trigger/Trigger {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;CLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function6;Ljava/util/Set;ZI)V
+	public synthetic fun <init> (Ljava/lang/String;CLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function6;Ljava/util/Set;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChar ()C
+	public final fun getDrawStyle ()Lkotlin/jvm/functions/Function6;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxQueryLength ()I
+	public final fun getRequireWordBoundary ()Z
+	public final fun getStopChars ()Ljava/util/Set;
+	public final fun getStyle ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/mohamedrejeb/richeditor/model/trigger/TriggerKt {
+	public static final fun getDefaultTriggerStopChars ()Ljava/util/Set;
+}
+
+public final class com/mohamedrejeb/richeditor/model/trigger/TriggerQuery {
+	public static final field $stable I
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLandroidx/compose/ui/geometry/Rect;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-d9O1mEE ()J
+	public final fun component4 ()Landroidx/compose/ui/geometry/Rect;
+	public final fun copy-YmzfRxQ (Ljava/lang/String;Ljava/lang/String;JLandroidx/compose/ui/geometry/Rect;)Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;
+	public static synthetic fun copy-YmzfRxQ$default (Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;Ljava/lang/String;Ljava/lang/String;JLandroidx/compose/ui/geometry/Rect;ILjava/lang/Object;)Lcom/mohamedrejeb/richeditor/model/trigger/TriggerQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaretRect ()Landroidx/compose/ui/geometry/Rect;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getRange-d9O1mEE ()J
+	public final fun getTriggerId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -391,6 +457,10 @@ public final class com/mohamedrejeb/richeditor/ui/material3/RichTextEditorKt {
 
 public final class com/mohamedrejeb/richeditor/ui/material3/RichTextKt {
 	public static final fun RichText-a0LXGaU (Lcom/mohamedrejeb/richeditor/model/RichTextState;Landroidx/compose/ui/Modifier;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;IJIZIILjava/util/Map;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Lcom/mohamedrejeb/richeditor/model/ImageLoader;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class com/mohamedrejeb/richeditor/ui/material3/TriggerSuggestionsKt {
+	public static final fun TriggerSuggestions-aF7bR5A (Lcom/mohamedrejeb/richeditor/model/RichTextState;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;FJJJLandroidx/compose/ui/graphics/Shape;ILkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/mohamedrejeb/richeditor/utils/FloatUtilsKt {

--- a/richeditor-compose/api/richeditor-compose.klib.api
+++ b/richeditor-compose/api/richeditor-compose.klib.api
@@ -23,6 +23,8 @@ abstract interface com.mohamedrejeb.richeditor.model/RichSpanStyle { // com.moha
         abstract fun <get-acceptNewTextInTheEdges>(): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.acceptNewTextInTheEdges.<get-acceptNewTextInTheEdges>|<get-acceptNewTextInTheEdges>(){}[0]
     abstract val spanStyle // com.mohamedrejeb.richeditor.model/RichSpanStyle.spanStyle|{}spanStyle[0]
         abstract fun <get-spanStyle>(): kotlin/Function1<com.mohamedrejeb.richeditor.model/RichTextConfig, androidx.compose.ui.text/SpanStyle> // com.mohamedrejeb.richeditor.model/RichSpanStyle.spanStyle.<get-spanStyle>|<get-spanStyle>(){}[0]
+    open val isAtomic // com.mohamedrejeb.richeditor.model/RichSpanStyle.isAtomic|{}isAtomic[0]
+        open fun <get-isAtomic>(): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.isAtomic.<get-isAtomic>|<get-isAtomic>(){}[0]
 
     abstract fun (androidx.compose.ui.graphics.drawscope/DrawScope).drawCustomStyle(androidx.compose.ui.text/TextLayoutResult, androidx.compose.ui.text/TextRange, com.mohamedrejeb.richeditor.model/RichTextConfig, kotlin/Float = ..., kotlin/Float = ...) // com.mohamedrejeb.richeditor.model/RichSpanStyle.drawCustomStyle|drawCustomStyle@androidx.compose.ui.graphics.drawscope.DrawScope(androidx.compose.ui.text.TextLayoutResult;androidx.compose.ui.text.TextRange;com.mohamedrejeb.richeditor.model.RichTextConfig;kotlin.Float;kotlin.Float){}[0]
     open fun (androidx.compose.ui.text/AnnotatedString.Builder).appendCustomContent(com.mohamedrejeb.richeditor.model/RichTextState): androidx.compose.ui.text/AnnotatedString.Builder // com.mohamedrejeb.richeditor.model/RichSpanStyle.appendCustomContent|appendCustomContent@androidx.compose.ui.text.AnnotatedString.Builder(com.mohamedrejeb.richeditor.model.RichTextState){}[0]
@@ -47,6 +49,8 @@ abstract interface com.mohamedrejeb.richeditor.model/RichSpanStyle { // com.moha
             final fun <get-acceptNewTextInTheEdges>(): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.acceptNewTextInTheEdges.<get-acceptNewTextInTheEdges>|<get-acceptNewTextInTheEdges>(){}[0]
         final val contentDescription // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.contentDescription|{}contentDescription[0]
             final fun <get-contentDescription>(): kotlin/String? // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.contentDescription.<get-contentDescription>|<get-contentDescription>(){}[0]
+        final val isAtomic // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.isAtomic|{}isAtomic[0]
+            final fun <get-isAtomic>(): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.isAtomic.<get-isAtomic>|<get-isAtomic>(){}[0]
         final val model // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.model|{}model[0]
             final fun <get-model>(): kotlin/Any // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.model.<get-model>|<get-model>(){}[0]
         final val spanStyle // com.mohamedrejeb.richeditor.model/RichSpanStyle.Image.spanStyle|{}spanStyle[0]
@@ -76,6 +80,28 @@ abstract interface com.mohamedrejeb.richeditor.model/RichSpanStyle { // com.moha
         final fun (androidx.compose.ui.graphics.drawscope/DrawScope).drawCustomStyle(androidx.compose.ui.text/TextLayoutResult, androidx.compose.ui.text/TextRange, com.mohamedrejeb.richeditor.model/RichTextConfig, kotlin/Float, kotlin/Float) // com.mohamedrejeb.richeditor.model/RichSpanStyle.Link.drawCustomStyle|drawCustomStyle@androidx.compose.ui.graphics.drawscope.DrawScope(androidx.compose.ui.text.TextLayoutResult;androidx.compose.ui.text.TextRange;com.mohamedrejeb.richeditor.model.RichTextConfig;kotlin.Float;kotlin.Float){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.Link.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // com.mohamedrejeb.richeditor.model/RichSpanStyle.Link.hashCode|hashCode(){}[0]
+    }
+
+    final class Token : com.mohamedrejeb.richeditor.model/RichSpanStyle { // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token|null[0]
+        constructor <init>(kotlin/String, kotlin/String, kotlin/String) // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.<init>|<init>(kotlin.String;kotlin.String;kotlin.String){}[0]
+
+        final val acceptNewTextInTheEdges // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.acceptNewTextInTheEdges|{}acceptNewTextInTheEdges[0]
+            final fun <get-acceptNewTextInTheEdges>(): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.acceptNewTextInTheEdges.<get-acceptNewTextInTheEdges>|<get-acceptNewTextInTheEdges>(){}[0]
+        final val id // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.id|{}id[0]
+            final fun <get-id>(): kotlin/String // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.id.<get-id>|<get-id>(){}[0]
+        final val isAtomic // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.isAtomic|{}isAtomic[0]
+            final fun <get-isAtomic>(): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.isAtomic.<get-isAtomic>|<get-isAtomic>(){}[0]
+        final val label // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.label|{}label[0]
+            final fun <get-label>(): kotlin/String // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.label.<get-label>|<get-label>(){}[0]
+        final val spanStyle // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.spanStyle|{}spanStyle[0]
+            final fun <get-spanStyle>(): kotlin/Function1<com.mohamedrejeb.richeditor.model/RichTextConfig, androidx.compose.ui.text/SpanStyle> // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.spanStyle.<get-spanStyle>|<get-spanStyle>(){}[0]
+        final val triggerId // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.triggerId|{}triggerId[0]
+            final fun <get-triggerId>(): kotlin/String // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.triggerId.<get-triggerId>|<get-triggerId>(){}[0]
+
+        final fun (androidx.compose.ui.graphics.drawscope/DrawScope).drawCustomStyle(androidx.compose.ui.text/TextLayoutResult, androidx.compose.ui.text/TextRange, com.mohamedrejeb.richeditor.model/RichTextConfig, kotlin/Float, kotlin/Float) // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.drawCustomStyle|drawCustomStyle@androidx.compose.ui.graphics.drawscope.DrawScope(androidx.compose.ui.text.TextLayoutResult;androidx.compose.ui.text.TextRange;com.mohamedrejeb.richeditor.model.RichTextConfig;kotlin.Float;kotlin.Float){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.mohamedrejeb.richeditor.model/RichSpanStyle.Token.toString|toString(){}[0]
     }
 
     final object Companion // com.mohamedrejeb.richeditor.model/RichSpanStyle.Companion|null[0]
@@ -136,6 +162,51 @@ abstract interface com.mohamedrejeb.richeditor.paragraph.type/OrderedListStyleTy
     }
 }
 
+final class com.mohamedrejeb.richeditor.model.trigger/Trigger { // com.mohamedrejeb.richeditor.model.trigger/Trigger|null[0]
+    constructor <init>(kotlin/String, kotlin/Char, kotlin/Function1<com.mohamedrejeb.richeditor.model/RichTextConfig, androidx.compose.ui.text/SpanStyle> = ..., kotlin/Function6<androidx.compose.ui.graphics.drawscope/DrawScope, androidx.compose.ui.text/TextLayoutResult, androidx.compose.ui.text/TextRange, com.mohamedrejeb.richeditor.model/RichTextConfig, kotlin/Float, kotlin/Float, kotlin/Unit>? = ..., kotlin.collections/Set<kotlin/Char> = ..., kotlin/Boolean = ..., kotlin/Int = ...) // com.mohamedrejeb.richeditor.model.trigger/Trigger.<init>|<init>(kotlin.String;kotlin.Char;kotlin.Function1<com.mohamedrejeb.richeditor.model.RichTextConfig,androidx.compose.ui.text.SpanStyle>;kotlin.Function6<androidx.compose.ui.graphics.drawscope.DrawScope,androidx.compose.ui.text.TextLayoutResult,androidx.compose.ui.text.TextRange,com.mohamedrejeb.richeditor.model.RichTextConfig,kotlin.Float,kotlin.Float,kotlin.Unit>?;kotlin.collections.Set<kotlin.Char>;kotlin.Boolean;kotlin.Int){}[0]
+
+    final val char // com.mohamedrejeb.richeditor.model.trigger/Trigger.char|{}char[0]
+        final fun <get-char>(): kotlin/Char // com.mohamedrejeb.richeditor.model.trigger/Trigger.char.<get-char>|<get-char>(){}[0]
+    final val drawStyle // com.mohamedrejeb.richeditor.model.trigger/Trigger.drawStyle|{}drawStyle[0]
+        final fun <get-drawStyle>(): kotlin/Function6<androidx.compose.ui.graphics.drawscope/DrawScope, androidx.compose.ui.text/TextLayoutResult, androidx.compose.ui.text/TextRange, com.mohamedrejeb.richeditor.model/RichTextConfig, kotlin/Float, kotlin/Float, kotlin/Unit>? // com.mohamedrejeb.richeditor.model.trigger/Trigger.drawStyle.<get-drawStyle>|<get-drawStyle>(){}[0]
+    final val id // com.mohamedrejeb.richeditor.model.trigger/Trigger.id|{}id[0]
+        final fun <get-id>(): kotlin/String // com.mohamedrejeb.richeditor.model.trigger/Trigger.id.<get-id>|<get-id>(){}[0]
+    final val maxQueryLength // com.mohamedrejeb.richeditor.model.trigger/Trigger.maxQueryLength|{}maxQueryLength[0]
+        final fun <get-maxQueryLength>(): kotlin/Int // com.mohamedrejeb.richeditor.model.trigger/Trigger.maxQueryLength.<get-maxQueryLength>|<get-maxQueryLength>(){}[0]
+    final val requireWordBoundary // com.mohamedrejeb.richeditor.model.trigger/Trigger.requireWordBoundary|{}requireWordBoundary[0]
+        final fun <get-requireWordBoundary>(): kotlin/Boolean // com.mohamedrejeb.richeditor.model.trigger/Trigger.requireWordBoundary.<get-requireWordBoundary>|<get-requireWordBoundary>(){}[0]
+    final val stopChars // com.mohamedrejeb.richeditor.model.trigger/Trigger.stopChars|{}stopChars[0]
+        final fun <get-stopChars>(): kotlin.collections/Set<kotlin/Char> // com.mohamedrejeb.richeditor.model.trigger/Trigger.stopChars.<get-stopChars>|<get-stopChars>(){}[0]
+    final val style // com.mohamedrejeb.richeditor.model.trigger/Trigger.style|{}style[0]
+        final fun <get-style>(): kotlin/Function1<com.mohamedrejeb.richeditor.model/RichTextConfig, androidx.compose.ui.text/SpanStyle> // com.mohamedrejeb.richeditor.model.trigger/Trigger.style.<get-style>|<get-style>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.mohamedrejeb.richeditor.model.trigger/Trigger.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.mohamedrejeb.richeditor.model.trigger/Trigger.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.mohamedrejeb.richeditor.model.trigger/Trigger.toString|toString(){}[0]
+}
+
+final class com.mohamedrejeb.richeditor.model.trigger/TriggerQuery { // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery|null[0]
+    constructor <init>(kotlin/String, kotlin/String, androidx.compose.ui.text/TextRange, androidx.compose.ui.geometry/Rect?) // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.<init>|<init>(kotlin.String;kotlin.String;androidx.compose.ui.text.TextRange;androidx.compose.ui.geometry.Rect?){}[0]
+
+    final val caretRect // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.caretRect|{}caretRect[0]
+        final fun <get-caretRect>(): androidx.compose.ui.geometry/Rect? // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.caretRect.<get-caretRect>|<get-caretRect>(){}[0]
+    final val query // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.query|{}query[0]
+        final fun <get-query>(): kotlin/String // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.query.<get-query>|<get-query>(){}[0]
+    final val range // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.range|{}range[0]
+        final fun <get-range>(): androidx.compose.ui.text/TextRange // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.range.<get-range>|<get-range>(){}[0]
+    final val triggerId // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.triggerId|{}triggerId[0]
+        final fun <get-triggerId>(): kotlin/String // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.triggerId.<get-triggerId>|<get-triggerId>(){}[0]
+
+    final fun component1(): kotlin/String // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.component1|component1(){}[0]
+    final fun component2(): kotlin/String // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.component2|component2(){}[0]
+    final fun component3(): androidx.compose.ui.text/TextRange // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.component3|component3(){}[0]
+    final fun component4(): androidx.compose.ui.geometry/Rect? // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., androidx.compose.ui.text/TextRange = ..., androidx.compose.ui.geometry/Rect? = ...): com.mohamedrejeb.richeditor.model.trigger/TriggerQuery // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.copy|copy(kotlin.String;kotlin.String;androidx.compose.ui.text.TextRange;androidx.compose.ui.geometry.Rect?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.mohamedrejeb.richeditor.model.trigger/TriggerQuery.toString|toString(){}[0]
+}
+
 final class com.mohamedrejeb.richeditor.model/ImageData { // com.mohamedrejeb.richeditor.model/ImageData|null[0]
     constructor <init>(androidx.compose.ui.graphics.painter/Painter, kotlin/String? = ..., androidx.compose.ui/Alignment = ..., androidx.compose.ui.layout/ContentScale = ..., androidx.compose.ui/Modifier = ...) // com.mohamedrejeb.richeditor.model/ImageData.<init>|<init>(androidx.compose.ui.graphics.painter.Painter;kotlin.String?;androidx.compose.ui.Alignment;androidx.compose.ui.layout.ContentScale;androidx.compose.ui.Modifier){}[0]
 
@@ -193,6 +264,8 @@ final class com.mohamedrejeb.richeditor.model/RichTextConfig { // com.mohamedrej
 final class com.mohamedrejeb.richeditor.model/RichTextState { // com.mohamedrejeb.richeditor.model/RichTextState|null[0]
     constructor <init>() // com.mohamedrejeb.richeditor.model/RichTextState.<init>|<init>(){}[0]
 
+    final val activeTriggerQuery // com.mohamedrejeb.richeditor.model/RichTextState.activeTriggerQuery|{}activeTriggerQuery[0]
+        final fun <get-activeTriggerQuery>(): com.mohamedrejeb.richeditor.model.trigger/TriggerQuery? // com.mohamedrejeb.richeditor.model/RichTextState.activeTriggerQuery.<get-activeTriggerQuery>|<get-activeTriggerQuery>(){}[0]
     final val composition // com.mohamedrejeb.richeditor.model/RichTextState.composition|{}composition[0]
         final fun <get-composition>(): androidx.compose.ui.text/TextRange? // com.mohamedrejeb.richeditor.model/RichTextState.composition.<get-composition>|<get-composition>(){}[0]
     final val config // com.mohamedrejeb.richeditor.model/RichTextState.config|{}config[0]
@@ -213,6 +286,8 @@ final class com.mohamedrejeb.richeditor.model/RichTextState { // com.mohamedreje
         final fun <get-selectedLinkText>(): kotlin/String? // com.mohamedrejeb.richeditor.model/RichTextState.selectedLinkText.<get-selectedLinkText>|<get-selectedLinkText>(){}[0]
     final val selectedLinkUrl // com.mohamedrejeb.richeditor.model/RichTextState.selectedLinkUrl|{}selectedLinkUrl[0]
         final fun <get-selectedLinkUrl>(): kotlin/String? // com.mohamedrejeb.richeditor.model/RichTextState.selectedLinkUrl.<get-selectedLinkUrl>|<get-selectedLinkUrl>(){}[0]
+    final val triggers // com.mohamedrejeb.richeditor.model/RichTextState.triggers|{}triggers[0]
+        final fun <get-triggers>(): kotlin.collections/List<com.mohamedrejeb.richeditor.model.trigger/Trigger> // com.mohamedrejeb.richeditor.model/RichTextState.triggers.<get-triggers>|<get-triggers>(){}[0]
 
     final var annotatedString // com.mohamedrejeb.richeditor.model/RichTextState.annotatedString|{}annotatedString[0]
         final fun <get-annotatedString>(): androidx.compose.ui.text/AnnotatedString // com.mohamedrejeb.richeditor.model/RichTextState.annotatedString.<get-annotatedString>|<get-annotatedString>(){}[0]
@@ -244,6 +319,7 @@ final class com.mohamedrejeb.richeditor.model/RichTextState { // com.mohamedreje
     final fun addTextAfterSelection(kotlin/String) // com.mohamedrejeb.richeditor.model/RichTextState.addTextAfterSelection|addTextAfterSelection(kotlin.String){}[0]
     final fun addTextAtIndex(kotlin/Int, kotlin/String) // com.mohamedrejeb.richeditor.model/RichTextState.addTextAtIndex|addTextAtIndex(kotlin.Int;kotlin.String){}[0]
     final fun addUnorderedList() // com.mohamedrejeb.richeditor.model/RichTextState.addUnorderedList|addUnorderedList(){}[0]
+    final fun cancelActiveTrigger() // com.mohamedrejeb.richeditor.model/RichTextState.cancelActiveTrigger|cancelActiveTrigger(){}[0]
     final fun clear() // com.mohamedrejeb.richeditor.model/RichTextState.clear|clear(){}[0]
     final fun clearRichSpans() // com.mohamedrejeb.richeditor.model/RichTextState.clearRichSpans|clearRichSpans(){}[0]
     final fun clearRichSpans(androidx.compose.ui.text/TextRange) // com.mohamedrejeb.richeditor.model/RichTextState.clearRichSpans|clearRichSpans(androidx.compose.ui.text.TextRange){}[0]
@@ -259,8 +335,10 @@ final class com.mohamedrejeb.richeditor.model/RichTextState { // com.mohamedreje
     final fun insertHtmlAfterSelection(kotlin/String) // com.mohamedrejeb.richeditor.model/RichTextState.insertHtmlAfterSelection|insertHtmlAfterSelection(kotlin.String){}[0]
     final fun insertMarkdown(kotlin/String, kotlin/Int) // com.mohamedrejeb.richeditor.model/RichTextState.insertMarkdown|insertMarkdown(kotlin.String;kotlin.Int){}[0]
     final fun insertMarkdownAfterSelection(kotlin/String) // com.mohamedrejeb.richeditor.model/RichTextState.insertMarkdownAfterSelection|insertMarkdownAfterSelection(kotlin.String){}[0]
+    final fun insertToken(kotlin/String, kotlin/String, kotlin/String) // com.mohamedrejeb.richeditor.model/RichTextState.insertToken|insertToken(kotlin.String;kotlin.String;kotlin.String){}[0]
     final fun isRichSpan(com.mohamedrejeb.richeditor.model/RichSpanStyle): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichTextState.isRichSpan|isRichSpan(com.mohamedrejeb.richeditor.model.RichSpanStyle){}[0]
     final fun isRichSpan(kotlin.reflect/KClass<out com.mohamedrejeb.richeditor.model/RichSpanStyle>): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichTextState.isRichSpan|isRichSpan(kotlin.reflect.KClass<out|com.mohamedrejeb.richeditor.model.RichSpanStyle>){}[0]
+    final fun registerTrigger(com.mohamedrejeb.richeditor.model.trigger/Trigger) // com.mohamedrejeb.richeditor.model/RichTextState.registerTrigger|registerTrigger(com.mohamedrejeb.richeditor.model.trigger.Trigger){}[0]
     final fun removeCode() // com.mohamedrejeb.richeditor.model/RichTextState.removeCode|removeCode(){}[0]
     final fun removeCodeSpan() // com.mohamedrejeb.richeditor.model/RichTextState.removeCodeSpan|removeCodeSpan(){}[0]
     final fun removeLink() // com.mohamedrejeb.richeditor.model/RichTextState.removeLink|removeLink(){}[0]
@@ -292,6 +370,7 @@ final class com.mohamedrejeb.richeditor.model/RichTextState { // com.mohamedreje
     final fun toggleRichSpan(com.mohamedrejeb.richeditor.model/RichSpanStyle) // com.mohamedrejeb.richeditor.model/RichTextState.toggleRichSpan|toggleRichSpan(com.mohamedrejeb.richeditor.model.RichSpanStyle){}[0]
     final fun toggleSpanStyle(androidx.compose.ui.text/SpanStyle) // com.mohamedrejeb.richeditor.model/RichTextState.toggleSpanStyle|toggleSpanStyle(androidx.compose.ui.text.SpanStyle){}[0]
     final fun toggleUnorderedList() // com.mohamedrejeb.richeditor.model/RichTextState.toggleUnorderedList|toggleUnorderedList(){}[0]
+    final fun unregisterTrigger(kotlin/String) // com.mohamedrejeb.richeditor.model/RichTextState.unregisterTrigger|unregisterTrigger(kotlin.String){}[0]
     final fun updateLink(kotlin/String) // com.mohamedrejeb.richeditor.model/RichTextState.updateLink|updateLink(kotlin.String){}[0]
     final inline fun <#A1: reified com.mohamedrejeb.richeditor.model/RichSpanStyle> isRichSpan(): kotlin/Boolean // com.mohamedrejeb.richeditor.model/RichTextState.isRichSpan|isRichSpan(){0§<com.mohamedrejeb.richeditor.model.RichSpanStyle>}[0]
 
@@ -370,6 +449,10 @@ final object com.mohamedrejeb.richeditor.ui.material3/RichTextEditorDefaults { /
     final fun richTextEditorWithoutLabelPadding(androidx.compose.ui.unit/Dp = ..., androidx.compose.ui.unit/Dp = ..., androidx.compose.ui.unit/Dp = ..., androidx.compose.ui.unit/Dp = ...): androidx.compose.foundation.layout/PaddingValues // com.mohamedrejeb.richeditor.ui.material3/RichTextEditorDefaults.richTextEditorWithoutLabelPadding|richTextEditorWithoutLabelPadding(androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp;androidx.compose.ui.unit.Dp){}[0]
 }
 
+final val com.mohamedrejeb.richeditor.model.trigger/DefaultTriggerStopChars // com.mohamedrejeb.richeditor.model.trigger/DefaultTriggerStopChars|{}DefaultTriggerStopChars[0]
+    final fun <get-DefaultTriggerStopChars>(): kotlin.collections/Set<kotlin/Char> // com.mohamedrejeb.richeditor.model.trigger/DefaultTriggerStopChars.<get-DefaultTriggerStopChars>|<get-DefaultTriggerStopChars>(){}[0]
+final val com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_Trigger$stableprop // com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_Trigger$stableprop|#static{}com_mohamedrejeb_richeditor_model_trigger_Trigger$stableprop[0]
+final val com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_TriggerQuery$stableprop // com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_TriggerQuery$stableprop|#static{}com_mohamedrejeb_richeditor_model_trigger_TriggerQuery$stableprop[0]
 final val com.mohamedrejeb.richeditor.model/LocalImageLoader // com.mohamedrejeb.richeditor.model/LocalImageLoader|{}LocalImageLoader[0]
     final fun <get-LocalImageLoader>(): androidx.compose.runtime/ProvidableCompositionLocal<com.mohamedrejeb.richeditor.model/ImageLoader> // com.mohamedrejeb.richeditor.model/LocalImageLoader.<get-LocalImageLoader>|<get-LocalImageLoader>(){}[0]
 final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_DefaultImageLoader$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_DefaultImageLoader$stableprop|#static{}com_mohamedrejeb_richeditor_model_DefaultImageLoader$stableprop[0]
@@ -378,6 +461,7 @@ final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_Ri
 final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Default$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Default$stableprop|#static{}com_mohamedrejeb_richeditor_model_RichSpanStyle_Default$stableprop[0]
 final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Image$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Image$stableprop|#static{}com_mohamedrejeb_richeditor_model_RichSpanStyle_Image$stableprop[0]
 final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Link$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Link$stableprop|#static{}com_mohamedrejeb_richeditor_model_RichSpanStyle_Link$stableprop[0]
+final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Token$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Token$stableprop|#static{}com_mohamedrejeb_richeditor_model_RichSpanStyle_Token$stableprop[0]
 final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextConfig$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextConfig$stableprop|#static{}com_mohamedrejeb_richeditor_model_RichTextConfig$stableprop[0]
 final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextState$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextState$stableprop|#static{}com_mohamedrejeb_richeditor_model_RichTextState$stableprop[0]
 final val com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_TextPaddingValues$stableprop // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_TextPaddingValues$stableprop|#static{}com_mohamedrejeb_richeditor_model_TextPaddingValues$stableprop[0]
@@ -397,12 +481,16 @@ final val com.mohamedrejeb.richeditor.ui.material3/com_mohamedrejeb_richeditor_u
 final fun (androidx.compose.ui.text.style/TextDecoration).com.mohamedrejeb.richeditor.utils/minus(androidx.compose.ui.text.style/TextDecoration): androidx.compose.ui.text.style/TextDecoration // com.mohamedrejeb.richeditor.utils/minus|minus@androidx.compose.ui.text.style.TextDecoration(androidx.compose.ui.text.style.TextDecoration){}[0]
 final fun (androidx.compose.ui.text/TextLayoutResult).com.mohamedrejeb.richeditor.utils/getBoundingBoxes(kotlin/Int, kotlin/Int, kotlin/Boolean = ...): kotlin.collections/List<androidx.compose.ui.geometry/Rect> // com.mohamedrejeb.richeditor.utils/getBoundingBoxes|getBoundingBoxes@androidx.compose.ui.text.TextLayoutResult(kotlin.Int;kotlin.Int;kotlin.Boolean){}[0]
 final fun (kotlin/Float).com.mohamedrejeb.richeditor.utils/maxDecimals(kotlin/Int): kotlin/Float // com.mohamedrejeb.richeditor.utils/maxDecimals|maxDecimals@kotlin.Float(kotlin.Int){}[0]
+final fun <#A: kotlin/Any?> com.mohamedrejeb.richeditor.ui.material3/TriggerSuggestions(com.mohamedrejeb.richeditor.model/RichTextState, kotlin/String, kotlin/Function1<kotlin/String, kotlin.collections/List<#A>>, kotlin/Function1<#A, com.mohamedrejeb.richeditor.model/RichSpanStyle.Token>, androidx.compose.ui/Modifier?, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Shape?, kotlin/Int, kotlin/Function3<#A, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int, kotlin/Int) // com.mohamedrejeb.richeditor.ui.material3/TriggerSuggestions|TriggerSuggestions(com.mohamedrejeb.richeditor.model.RichTextState;kotlin.String;kotlin.Function1<kotlin.String,kotlin.collections.List<0:0>>;kotlin.Function1<0:0,com.mohamedrejeb.richeditor.model.RichSpanStyle.Token>;androidx.compose.ui.Modifier?;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Shape?;kotlin.Int;kotlin.Function3<0:0,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int;kotlin.Int){0§<kotlin.Any?>}[0]
+final fun com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_Trigger$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_Trigger$stableprop_getter|com_mohamedrejeb_richeditor_model_trigger_Trigger$stableprop_getter(){}[0]
+final fun com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_TriggerQuery$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model.trigger/com_mohamedrejeb_richeditor_model_trigger_TriggerQuery$stableprop_getter|com_mohamedrejeb_richeditor_model_trigger_TriggerQuery$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_DefaultImageLoader$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_DefaultImageLoader$stableprop_getter|com_mohamedrejeb_richeditor_model_DefaultImageLoader$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_ImageData$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_ImageData$stableprop_getter|com_mohamedrejeb_richeditor_model_ImageData$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Code$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Code$stableprop_getter|com_mohamedrejeb_richeditor_model_RichSpanStyle_Code$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Default$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Default$stableprop_getter|com_mohamedrejeb_richeditor_model_RichSpanStyle_Default$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Image$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Image$stableprop_getter|com_mohamedrejeb_richeditor_model_RichSpanStyle_Image$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Link$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Link$stableprop_getter|com_mohamedrejeb_richeditor_model_RichSpanStyle_Link$stableprop_getter(){}[0]
+final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Token$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichSpanStyle_Token$stableprop_getter|com_mohamedrejeb_richeditor_model_RichSpanStyle_Token$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextConfig$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextConfig$stableprop_getter|com_mohamedrejeb_richeditor_model_RichTextConfig$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextState$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_RichTextState$stableprop_getter|com_mohamedrejeb_richeditor_model_RichTextState$stableprop_getter(){}[0]
 final fun com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_TextPaddingValues$stableprop_getter(): kotlin/Int // com.mohamedrejeb.richeditor.model/com_mohamedrejeb_richeditor_model_TextPaddingValues$stableprop_getter|com_mohamedrejeb_richeditor_model_TextPaddingValues$stableprop_getter(){}[0]

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpan.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpan.kt
@@ -175,7 +175,7 @@ internal class RichSpan(
      *
      * @return True if the rich span is empty, false otherwise
      */
-    fun isEmpty(): Boolean = text.isEmpty() && isChildrenEmpty() && richSpanStyle !is RichSpanStyle.Image
+    fun isEmpty(): Boolean = text.isEmpty() && isChildrenEmpty() && !richSpanStyle.isAtomic
 
     /**
      * Check if the rich span is blank.
@@ -183,7 +183,7 @@ internal class RichSpan(
      *
      * @return True if the rich span is blank, false otherwise
      */
-    fun isBlank(): Boolean = text.isBlank() && isChildrenBlank() && richSpanStyle !is RichSpanStyle.Image
+    fun isBlank(): Boolean = text.isBlank() && isChildrenBlank() && !richSpanStyle.isAtomic
 
     /**
      * Check if the rich span children are empty
@@ -256,7 +256,7 @@ internal class RichSpan(
      * @return True if the rich span is empty after trimming, false otherwise
      */
     internal fun trimStart(): Boolean {
-        if (richSpanStyle is RichSpanStyle.Image)
+        if (richSpanStyle.isAtomic)
             return false
 
         if (isBlank()) {
@@ -295,12 +295,12 @@ internal class RichSpan(
     }
 
     internal fun trimEnd(): Boolean {
-        val isImage = richSpanStyle is RichSpanStyle.Image
+        val isAtomic = richSpanStyle.isAtomic
 
-        if (isImage)
+        if (isAtomic)
             return false
 
-        val isChildrenBlank = isChildrenBlank() && !isImage
+        val isChildrenBlank = isChildrenBlank() && !isAtomic
 
         if (text.isBlank() && isChildrenBlank) {
             text = ""

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpanStyle.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpanStyle.kt
@@ -41,6 +41,15 @@ public interface RichSpanStyle {
      */
     public val acceptNewTextInTheEdges: Boolean
 
+    /**
+     * If true, the span is treated as a single atomic unit for editing:
+     * backspace deletes the whole span, typing adjacent to it creates a sibling span
+     * instead of appending into it, and selections that straddle the span snap to its edges.
+     *
+     * Defaults to false. Overridden to true by [Image] and atomic token spans (e.g. mentions).
+     */
+    public val isAtomic: Boolean get() = false
+
     public fun DrawScope.drawCustomStyle(
         layoutResult: TextLayoutResult,
         textRange: TextRange,
@@ -276,6 +285,8 @@ public interface RichSpanStyle {
         override val acceptNewTextInTheEdges: Boolean =
             false
 
+        override val isAtomic: Boolean = true
+
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is Image) return false
@@ -293,6 +304,60 @@ public interface RichSpanStyle {
             result = 31 * result + height.hashCode()
             return result
         }
+    }
+
+    /**
+     * Atomic token produced by committing a trigger query (see [com.mohamedrejeb.richeditor.model.trigger.Trigger]).
+     *
+     * Tokens are single indivisible units for editing purposes:
+     * backspace removes the whole [label], typing adjacent to a token creates
+     * a sibling span, and selections that straddle a token snap to its edges.
+     *
+     * @property triggerId Id of the [com.mohamedrejeb.richeditor.model.trigger.Trigger] that produced this token.
+     * Used at render time to look up the trigger's style and at serialization
+     * time to round-trip the token through HTML/Markdown.
+     * @property id Stable identity for the referenced entity (e.g. user id, tag slug, command name).
+     * Preserved across HTML/Markdown round-trips.
+     * @property label Display text of the token, including the trigger character
+     * (e.g. "@mohamed", "#release", "/help"). This text becomes the raw text
+     * of the span.
+     */
+    public class Token(
+        public val triggerId: String,
+        public val id: String,
+        public val label: String,
+    ) : RichSpanStyle {
+        override val spanStyle: (RichTextConfig) -> SpanStyle = {
+            SpanStyle(color = it.linkColor)
+        }
+
+        override fun DrawScope.drawCustomStyle(
+            layoutResult: TextLayoutResult,
+            textRange: TextRange,
+            richTextConfig: RichTextConfig,
+            topPadding: Float,
+            startPadding: Float,
+        ): Unit = Unit
+
+        override val acceptNewTextInTheEdges: Boolean = false
+
+        override val isAtomic: Boolean = true
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Token) return false
+            return triggerId == other.triggerId && id == other.id && label == other.label
+        }
+
+        override fun hashCode(): Int {
+            var result = triggerId.hashCode()
+            result = 31 * result + id.hashCode()
+            result = 31 * result + label.hashCode()
+            return result
+        }
+
+        override fun toString(): String =
+            "Token(triggerId='$triggerId', id='$id', label='$label')"
     }
 
     public data object Default : RichSpanStyle {

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -30,6 +30,9 @@ import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.util.fastForEachReversed
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.trigger.Trigger
+import com.mohamedrejeb.richeditor.model.trigger.TriggerQuery
+import com.mohamedrejeb.richeditor.model.trigger.detectActiveTrigger
 import com.mohamedrejeb.richeditor.paragraph.RichParagraph
 import com.mohamedrejeb.richeditor.paragraph.type.*
 import com.mohamedrejeb.richeditor.paragraph.type.ParagraphType.Companion.startText
@@ -115,6 +118,204 @@ public class RichTextState internal constructor(
         }
 
     public val composition: TextRange? get() = textFieldValue.composition
+
+    // --- Triggers (mentions, hashtags, commands, ...) ---
+    //
+    // Triggers live on RichTextState (not on editor composables) so tokens
+    // render correctly in read-only views and so programmatic insertion
+    // works without a mounted editor.
+
+    private val _triggers: MutableList<Trigger> = mutableStateListOf()
+
+    /**
+     * Registered triggers on this state. Use [registerTrigger] and [unregisterTrigger] to mutate.
+     */
+    @ExperimentalRichTextApi
+    public val triggers: List<Trigger> get() = _triggers
+
+    private var _activeTriggerQuery: TriggerQuery? by mutableStateOf(null)
+
+    /**
+     * Snapshot of the in-progress trigger query, or `null` if no trigger is active.
+     *
+     * Observed by suggestion UI composables (e.g. `TriggerSuggestions`) to know when to render
+     * a popup, what trigger is active, what query text to match against, and where to anchor.
+     *
+     * Updated automatically after every text edit and selection change.
+     */
+    @ExperimentalRichTextApi
+    public val activeTriggerQuery: TriggerQuery? get() = _activeTriggerQuery
+
+    /**
+     * Text range that was dismissed by [cancelActiveTrigger]. Used to suppress
+     * immediate re-activation if the cursor is still within the dismissed range.
+     */
+    private var suppressedTriggerRange: TextRange? = null
+
+    /**
+     * Window-space position of the hosted [BasicTextField]. Captured via
+     * [androidx.compose.ui.layout.onGloballyPositioned] on the editor's modifier
+     * chain; used by suggestion popups to anchor relative to the caret in window coords.
+     */
+    internal var textFieldWindowPosition: Offset = Offset.Zero
+
+    /**
+     * Key handler installed by the currently-visible trigger suggestions popup.
+     * Consulted by [onPreviewKeyEvent] before the editor's default behavior, so
+     * ↑/↓/Enter/Esc can drive the popup instead of reaching the text field.
+     */
+    internal var triggerKeyHandler: ((KeyEvent) -> Boolean)? = null
+
+    /**
+     * Register a [trigger] on this state. Triggers that share a character with an already
+     * registered trigger are rejected with [IllegalArgumentException] to keep detection deterministic.
+     *
+     * Registering a trigger with a previously used [Trigger.id] replaces the previous registration.
+     */
+    @ExperimentalRichTextApi
+    public fun registerTrigger(trigger: Trigger) {
+        val charCollision = _triggers.firstOrNull { it.char == trigger.char && it.id != trigger.id }
+        require(charCollision == null) {
+            "Trigger char '${trigger.char}' is already registered by trigger id='${charCollision?.id}'"
+        }
+        val existingIndex = _triggers.indexOfFirst { it.id == trigger.id }
+        if (existingIndex >= 0) {
+            // Remove + add instead of set() — Trigger's equals compares by id, so
+            // list.set(i, trigger) may be a no-op under equality-tracking list
+            // implementations even though the values differ.
+            _triggers.removeAt(existingIndex)
+            _triggers.add(existingIndex, trigger)
+        } else {
+            _triggers.add(trigger)
+        }
+    }
+
+    /**
+     * Remove the trigger registered under [id]. No-op if not registered.
+     * If the currently active query belongs to [id], it is cleared.
+     */
+    @ExperimentalRichTextApi
+    public fun unregisterTrigger(id: String) {
+        _triggers.removeAll { it.id == id }
+        if (_activeTriggerQuery?.triggerId == id) {
+            _activeTriggerQuery = null
+        }
+    }
+
+    /**
+     * Internal lookup from trigger id to its [Trigger] definition, used by the render
+     * path to resolve token styling. Returns `null` for unknown ids (e.g. a [RichSpanStyle.Token]
+     * parsed from HTML whose trigger isn't registered on the receiving state).
+     */
+    internal fun findTrigger(id: String): Trigger? =
+        _triggers.firstOrNull { it.id == id }
+
+    /**
+     * Commit a token for the currently active trigger query.
+     *
+     * Replaces the active query's raw-text range (trigger char + query chars) with an
+     * atomic [RichSpanStyle.Token] span followed by a trailing space, then clears the query.
+     *
+     * @param triggerId Must match [activeTriggerQuery]'s triggerId.
+     * @param id Stable identity for the referenced entity (e.g. "u123").
+     * @param label Display text of the token. Must start with the trigger's character.
+     * @throws IllegalStateException if no matching query is active.
+     * @throws IllegalArgumentException if [label] does not start with the trigger character.
+     */
+    @ExperimentalRichTextApi
+    public fun insertToken(triggerId: String, id: String, label: String) {
+        val query = _activeTriggerQuery
+        checkNotNull(query) { "No active trigger query to commit" }
+        check(query.triggerId == triggerId) {
+            "Active query is for '${query.triggerId}', not '$triggerId'"
+        }
+        val trigger = findTrigger(triggerId)
+        checkNotNull(trigger) { "Trigger '$triggerId' is not registered" }
+        require(label.isNotEmpty() && label.first() == trigger.char) {
+            "Token label must start with trigger char '${trigger.char}', got '$label'"
+        }
+        performInsertToken(query = query, triggerId = triggerId, id = id, label = label)
+    }
+
+    /**
+     * Dismiss the active trigger query without inserting a token. Leaves the typed text in place
+     * (e.g. `@moh` stays as plain characters) and suppresses immediate re-detection until the
+     * cursor leaves the typed range.
+     */
+    @ExperimentalRichTextApi
+    public fun cancelActiveTrigger() {
+        val query = _activeTriggerQuery ?: return
+        suppressedTriggerRange = query.range
+        _activeTriggerQuery = null
+    }
+
+    /**
+     * Splice a [RichSpanStyle.Token] into the tree at [query]'s range in a single atomic edit:
+     *
+     *  1. remove the old query chars (e.g. "@moh") via the standard edit pipeline;
+     *  2. build an atomic Token span + trailing plain-text space span manually;
+     *  3. attach both as children of the span at the caret, which guarantees they
+     *     land in the same paragraph regardless of document structure;
+     *  4. update the raw text and caret in a single [updateTextFieldValue] pass.
+     *
+     * The earlier two-`addTextAtIndex` implementation was fragile around paragraph
+     * boundaries: the trailing-space call could route the space into the next
+     * paragraph when the Token sat at a paragraph end. `addRichSpanAtPosition`
+     * inherits the target paragraph from the span at the caret, so the space
+     * always lands next to the Token.
+     */
+    private fun performInsertToken(
+        query: TriggerQuery,
+        triggerId: String,
+        id: String,
+        label: String,
+    ) {
+        _activeTriggerQuery = null
+        suppressedTriggerRange = null
+
+        if (!query.range.collapsed) {
+            removeTextRange(query.range)
+        }
+
+        val insertIndex = query.range.min
+        val trigger = findTrigger(triggerId) ?: return
+        val triggerSpanStyle = trigger.style(config)
+
+        val anchor = getRichSpanByTextIndex(insertIndex - 1)
+        val targetParagraph = anchor?.paragraph
+            ?: richParagraphList.firstOrNull()
+            ?: return
+
+        val tokenSpan = RichSpan(
+            text = label,
+            paragraph = targetParagraph,
+            richSpanStyle = RichSpanStyle.Token(
+                triggerId = triggerId,
+                id = id,
+                label = label,
+            ),
+            spanStyle = triggerSpanStyle,
+        )
+        val spaceSpan = RichSpan(
+            text = " ",
+            paragraph = targetParagraph,
+        )
+
+        addRichSpanAtPosition(tokenSpan, spaceSpan, index = insertIndex)
+
+        val currentText = textFieldValue.text
+        val before = currentText.substring(0, insertIndex)
+        val after = currentText.substring(insertIndex)
+        val newText = before + label + " " + after
+        val newSelection = TextRange(insertIndex + label.length + 1)
+
+        updateTextFieldValue(
+            newTextFieldValue = textFieldValue.copy(
+                text = newText,
+                selection = newSelection,
+            )
+        )
+    }
 
     internal var singleParagraphMode by mutableStateOf(false)
 
@@ -1392,6 +1593,12 @@ public class RichTextState internal constructor(
      * @return true if the list level was increased or decreased, false otherwise.
      */
     internal fun onPreviewKeyEvent(event: KeyEvent): Boolean {
+        // Give trigger-suggestions popup first refusal on key events while a query is active.
+        // Popup handlers return true when they consume the event (↑/↓/Enter/Esc navigation).
+        triggerKeyHandler?.invoke(event)?.let { handled ->
+            if (handled) return true
+        }
+
         if (event.type != KeyEventType.KeyDown)
             return false
 
@@ -1701,8 +1908,58 @@ public class RichTextState internal constructor(
         // Update current paragraph style
         updateCurrentParagraphStyle()
 
+        // Re-detect active trigger query after every edit / selection change
+        refreshActiveTriggerQuery()
+
         // Clear [tempTextFieldValue]
         tempTextFieldValue = TextFieldValue()
+    }
+
+    /**
+     * Recompute [activeTriggerQuery] from the current text + caret + registered triggers.
+     * Called from [updateTextFieldValue] after every edit.
+     */
+    private fun refreshActiveTriggerQuery() {
+        if (_triggers.isEmpty()) {
+            _activeTriggerQuery = null
+            suppressedTriggerRange = null
+            return
+        }
+
+        val selection = textFieldValue.selection
+        if (!selection.collapsed) {
+            _activeTriggerQuery = null
+            return
+        }
+
+        // Clear suppression if the caret has left the suppressed range.
+        val suppress = suppressedTriggerRange
+        if (suppress != null) {
+            val caret = selection.min
+            val outside = caret < suppress.min || caret > suppress.max
+            if (outside) {
+                suppressedTriggerRange = null
+            }
+        }
+
+        val caret = selection.min
+        val text = textFieldValue.text
+
+        // Guard against detection inside an existing atomic Token span — tokens
+        // are atomic units and can't host a nested active trigger.
+        val spanAtCaret = getRichSpanByTextIndex(caret - 1)
+        if (spanAtCaret?.richSpanStyle is RichSpanStyle.Token) {
+            _activeTriggerQuery = null
+            return
+        }
+
+        _activeTriggerQuery = detectActiveTrigger(
+            text = text,
+            caretOffset = caret,
+            triggers = _triggers,
+            textLayoutResult = textLayoutResult,
+            suppressedRange = suppressedTriggerRange,
+        )
     }
 
     /**
@@ -1806,11 +2063,10 @@ public class RichTextState internal constructor(
 
         val candidateRichSpan = getOrCreateRichSpanByTextIndex(previousIndex)
 
-        // Image spans own a single placeholder char in the raw text; typed
-        // characters adjacent to an image must go into a new sibling span
-        // rather than be appended onto the image span's text. See #466.
+        // Atomic spans (Image, Token, ...) must not absorb adjacent typing;
+        // characters next to them go into a new sibling span instead. See #466.
         val activeRichSpan =
-            if (candidateRichSpan?.richSpanStyle is RichSpanStyle.Image)
+            if (candidateRichSpan?.richSpanStyle?.isAtomic == true)
                 null
             else
                 candidateRichSpan
@@ -1922,7 +2178,7 @@ public class RichTextState internal constructor(
             }
 
             val imageSibling =
-                candidateRichSpan?.takeIf { it.richSpanStyle is RichSpanStyle.Image }
+                candidateRichSpan?.takeIf { it.richSpanStyle.isAtomic }
             val paragraph = imageSibling?.paragraph ?: richParagraphList.last()
             val newRichSpan = RichSpan(
                 paragraph = paragraph,
@@ -3465,6 +3721,24 @@ public class RichTextState internal constructor(
         adjustRichParagraphLayout(
             density = density,
         )
+        // When the user adds characters, refreshActiveTriggerQuery runs against the
+        // OLD text layout (the new caret position is past the old layout's valid range),
+        // so caretRect ends up stale. Re-resolve it now that we have the fresh layout.
+        refreshActiveTriggerCaretRect()
+    }
+
+    /**
+     * Update the active query's [TriggerQuery.caretRect] using the current [textLayoutResult].
+     * No-op when there is no active query or no layout yet.
+     */
+    private fun refreshActiveTriggerCaretRect() {
+        val query = _activeTriggerQuery ?: return
+        val layout = textLayoutResult ?: return
+        val caret = textFieldValue.selection.min
+        val fresh = runCatching { layout.getCursorRect(caret) }.getOrNull()
+        if (fresh != query.caretRect) {
+            _activeTriggerQuery = query.copy(caretRect = fresh)
+        }
     }
 
     private fun adjustRichParagraphLayout(
@@ -4377,8 +4651,8 @@ public class RichTextState internal constructor(
             // Recursively trim children
             trimSpanList(span.children, rangeStart, rangeEnd)
 
-            // Mark empty spans for removal
-            if (span.text.isEmpty() && span.children.isEmpty() && span.richSpanStyle !is RichSpanStyle.Image) {
+            // Mark empty spans for removal (atomic spans like Image/Token keep their placeholder)
+            if (span.text.isEmpty() && span.children.isEmpty() && !span.richSpanStyle.isAtomic) {
                 toRemove.add(i)
             }
         }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/trigger/Trigger.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/trigger/Trigger.kt
@@ -1,0 +1,73 @@
+package com.mohamedrejeb.richeditor.model.trigger
+
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichTextConfig
+
+/**
+ * Default characters that cancel an in-progress trigger query.
+ *
+ * When the user types any of these characters after a trigger character (e.g. `@`),
+ * the active query is cleared and the text remains as plain characters.
+ */
+public val DefaultTriggerStopChars: Set<Char> = setOf(' ', '\n', '\t')
+
+/**
+ * Defines a single-character trigger that activates a token-insertion flow.
+ *
+ * A [Trigger] describes a feature like `@mentions`, `#hashtags`, or `/commands`:
+ * when the user types the [char], the editor enters "query mode" and collects
+ * characters until a [stopChars] character is typed or a token is committed
+ * via [com.mohamedrejeb.richeditor.model.RichTextState.insertToken].
+ *
+ * Register triggers on [com.mohamedrejeb.richeditor.model.RichTextState.registerTrigger].
+ *
+ * @property id Stable identifier for this trigger. Used as the key for matching
+ * [TriggerQuery.triggerId] and [Token.triggerId], and for round-trip
+ * serialization to HTML/Markdown. Must be unique per [RichTextState].
+ * @property char The single character that activates this trigger. Must be unique
+ * across all registered triggers on the same state.
+ * @property style Applied to committed [Token] spans of this trigger.
+ * Receives the live [RichTextConfig] so colors can follow the editor theme.
+ * @property drawStyle Optional custom draw logic (e.g. background pill) applied
+ * beneath the token text. Follows the same contract as
+ * [com.mohamedrejeb.richeditor.model.RichSpanStyle.drawCustomStyle].
+ * @property stopChars Characters that cancel an in-progress query. Defaults to
+ * whitespace ([DefaultTriggerStopChars]).
+ * @property requireWordBoundary When true, the trigger only activates when the
+ * preceding character is whitespace, a paragraph boundary, or nothing. This
+ * prevents activation inside words (e.g. `foo@bar` does not trigger a mention).
+ * Defaults to true.
+ * @property maxQueryLength Maximum number of characters permitted after the
+ * trigger character before the query is abandoned. Defaults to 50.
+ */
+@ExperimentalRichTextApi
+public class Trigger(
+    public val id: String,
+    public val char: Char,
+    public val style: (RichTextConfig) -> SpanStyle = { SpanStyle(color = it.linkColor) },
+    public val drawStyle: (DrawScope.(TextLayoutResult, TextRange, RichTextConfig, Float, Float) -> Unit)? = null,
+    public val stopChars: Set<Char> = DefaultTriggerStopChars,
+    public val requireWordBoundary: Boolean = true,
+    public val maxQueryLength: Int = 50,
+) {
+    init {
+        require(id.isNotEmpty()) { "Trigger id must not be empty" }
+        require(':' !in id) { "Trigger id must not contain ':' (used as Markdown round-trip separator)" }
+        require(char !in stopChars) { "Trigger char '$char' cannot be one of its stopChars" }
+        require(maxQueryLength > 0) { "maxQueryLength must be positive, got $maxQueryLength" }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Trigger) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String = "Trigger(id='$id', char='$char')"
+}

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/trigger/TriggerDetector.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/trigger/TriggerDetector.kt
@@ -1,0 +1,103 @@
+package com.mohamedrejeb.richeditor.model.trigger
+
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+
+/**
+ * Scan [text] backwards from [caretOffset] looking for a registered trigger,
+ * producing a [TriggerQuery] describing the in-progress token insertion or
+ * `null` if no trigger is active at the caret position.
+ *
+ * The scan terminates as soon as any of the following is true:
+ *  - a character in the active trigger's `stopChars` is encountered (no activation);
+ *  - a registered trigger character is found (candidate activation);
+ *  - [Trigger.maxQueryLength] characters have been scanned without finding a trigger (no activation);
+ *  - the start of the text is reached.
+ *
+ * When a trigger character is found, the function additionally validates:
+ *  - word-boundary requirement, if [Trigger.requireWordBoundary] is true;
+ *  - the suppressed range guard — if [suppressedRange] contains the trigger
+ *    position, activation is skipped. This prevents a just-cancelled query
+ *    from immediately re-activating while the caret is still within its range.
+ */
+@ExperimentalRichTextApi
+internal fun detectActiveTrigger(
+    text: String,
+    caretOffset: Int,
+    triggers: List<Trigger>,
+    textLayoutResult: TextLayoutResult?,
+    suppressedRange: TextRange?,
+): TriggerQuery? {
+    if (triggers.isEmpty()) return null
+    if (caretOffset <= 0 || caretOffset > text.length) return null
+
+    val triggerByChar: Map<Char, Trigger> = triggers.associateBy { it.char }
+
+    // Use the global maximum across triggers as the scan cap. Per-trigger maxQueryLength
+    // validation happens after a candidate trigger is found.
+    val scanCap = triggers.maxOf { it.maxQueryLength }
+
+    var i = caretOffset - 1
+    var scanned = 0
+    var lastStopCharIndex = -1
+
+    while (i >= 0 && scanned <= scanCap) {
+        val ch = text[i]
+
+        val candidate = triggerByChar[ch]
+        if (candidate != null) {
+            // Verify the substring between candidate and caret contains no stop chars
+            // for THIS trigger. (We may have passed over chars that would be stop chars
+            // for a different trigger; each trigger defines its own set.)
+            val queryStart = i + 1
+            val query = text.substring(queryStart, caretOffset)
+            val queryLength = caretOffset - queryStart
+
+            if (queryLength > candidate.maxQueryLength) return null
+            if (query.any { it in candidate.stopChars }) return null
+
+            if (candidate.requireWordBoundary) {
+                val prev = if (i == 0) null else text[i - 1]
+                val isBoundary = prev == null || prev.isWhitespace() || prev == '\n'
+                if (!isBoundary) return null
+            }
+
+            if (suppressedRange != null) {
+                val triggerPos = i
+                if (triggerPos in suppressedRange.min until suppressedRange.max ||
+                    triggerPos == suppressedRange.min
+                ) {
+                    return null
+                }
+            }
+
+            val range = TextRange(i, caretOffset)
+            val caretRect = textLayoutResult?.let {
+                runCatching { it.getCursorRect(caretOffset) }.getOrNull()
+            }
+
+            return TriggerQuery(
+                triggerId = candidate.id,
+                query = query,
+                range = range,
+                caretRect = caretRect,
+            )
+        }
+
+        // A char at the current scan position is a stop char if ANY registered
+        // trigger treats it as a stop char — once hit, no trigger can resume
+        // backwards through this char. This matches user intuition (whitespace
+        // always breaks a query regardless of which trigger is involved).
+        val isAnyStopChar = triggers.any { ch in it.stopChars }
+        if (isAnyStopChar) {
+            lastStopCharIndex = i
+            return null
+        }
+
+        i--
+        scanned++
+    }
+
+    return null
+}

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/trigger/TriggerQuery.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/trigger/TriggerQuery.kt
@@ -1,0 +1,34 @@
+package com.mohamedrejeb.richeditor.model.trigger
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.text.TextRange
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+
+/**
+ * Snapshot of an in-progress trigger query.
+ *
+ * When the user types a registered trigger character followed by zero or more
+ * query characters, [com.mohamedrejeb.richeditor.model.RichTextState.activeTriggerQuery]
+ * exposes this value. Consumers (typically a suggestions popup) observe it to:
+ *
+ *  - identify which trigger is active ([triggerId]);
+ *  - fetch matching suggestions for the current [query];
+ *  - anchor UI at [caretRect];
+ *  - know which text range will be replaced on commit ([range]).
+ *
+ * @property triggerId Id of the [Trigger] that produced this query.
+ * @property query Characters typed after the trigger character, excluding the
+ * trigger character itself. Empty when the user just typed the trigger char.
+ * @property range Raw-text range spanning the trigger character and the query.
+ * On commit, this entire range is replaced with the committed token text.
+ * @property caretRect The cursor's bounding rect at query time, in the editor's
+ * coordinate space. Null if no text layout is available yet. Consumers use
+ * this to position a popup.
+ */
+@ExperimentalRichTextApi
+public data class TriggerQuery(
+    public val triggerId: String,
+    public val query: String,
+    public val range: TextRange,
+    public val caretRect: Rect?,
+)

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
@@ -292,6 +292,25 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                 if (name in skippedHtmlElements)
                     return@onCloseTag
 
+                // Finalize Token labels: the richSpanStyle was created at open-tag time
+                // with an empty label; fill it now that the inner text has accumulated.
+                val closingSpan = currentRichSpan
+                val closingStyle = closingSpan?.richSpanStyle
+                if (name == "span" && closingStyle is RichSpanStyle.Token && closingStyle.label.isEmpty()) {
+                    val label = closingSpan.text.ifEmpty {
+                        // Fall back to collecting text from any accumulated children
+                        // (rare: nested inline styling inside a token).
+                        closingSpan.children.joinToString("") { it.text }
+                    }
+                    if (label.isNotEmpty()) {
+                        closingSpan.richSpanStyle = RichSpanStyle.Token(
+                            triggerId = closingStyle.triggerId,
+                            id = closingStyle.id,
+                            label = label,
+                        )
+                    }
+                }
+
                 if (name != BrElement)
                     currentRichSpan = currentRichSpan?.parent
             }
@@ -524,10 +543,12 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
         val tagName = spanHtml.first
         val tagAttributes = spanHtml.second
 
-        // Convert attributes map to HTML string
+        // Convert attributes map to HTML string. Values MUST be escaped to avoid producing
+        // malformed or XSS-capable HTML when attribute content comes from user data
+        // (e.g. Token ids, link hrefs, image alt text). See REVIEW.md §5.
         val tagAttributesStringBuilder = StringBuilder()
         tagAttributes.forEach { (key, value) ->
-            tagAttributesStringBuilder.append(" $key=\"$value\"")
+            tagAttributesStringBuilder.append(" $key=\"${escapeHtmlAttribute(value)}\"")
         }
 
         // Convert span style to CSS string
@@ -596,6 +617,21 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                     contentDescription = attributes["alt"] ?: ""
                 )
 
+            "span" -> {
+                val triggerId = attributes["data-trigger"]
+                val tokenId = attributes["data-id"]
+                if (!triggerId.isNullOrEmpty() && !tokenId.isNullOrEmpty()) {
+                    // Label is filled in at close-tag time once the inner text has accumulated.
+                    RichSpanStyle.Token(
+                        triggerId = triggerId,
+                        id = tokenId,
+                        label = "",
+                    )
+                } else {
+                    RichSpanStyle.Default
+                }
+            }
+
             else ->
                 RichSpanStyle.Default
         }
@@ -626,6 +662,12 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                     )
                 else
                     "span" to emptyMap()
+
+            is RichSpanStyle.Token ->
+                "span" to mapOf(
+                    "data-trigger" to richSpanStyle.triggerId,
+                    "data-id" to richSpanStyle.id,
+                )
 
             else ->
                 "span" to emptyMap()
@@ -668,6 +710,27 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
             is OrderedList -> "ol"
             else -> "p"
         }
+    }
+
+    /**
+     * Escape a value for inclusion inside a double-quoted HTML attribute.
+     * Replaces the characters that are unsafe in that context.
+     */
+    private fun escapeHtmlAttribute(value: String): String {
+        if (value.isEmpty()) return value
+        val needsEscape = value.any { it == '&' || it == '"' || it == '<' || it == '>' }
+        if (!needsEscape) return value
+        val sb = StringBuilder(value.length + 8)
+        for (ch in value) {
+            when (ch) {
+                '&' -> sb.append("&amp;")
+                '"' -> sb.append("&quot;")
+                '<' -> sb.append("&lt;")
+                '>' -> sb.append("&gt;")
+                else -> sb.append(ch)
+            }
+        }
+        return sb.toString()
     }
 
 }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
@@ -532,14 +532,26 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
                     ?.toString()
                     .orEmpty()
 
-                if (isImage)
-                    RichSpanStyle.Image(
-                        model = destination,
-                        width = 0.sp,
-                        height = 0.sp,
-                    )
-                else
-                    RichSpanStyle.Link(url = destination)
+                val linkLabel = node
+                    .findChildOfType(MarkdownElementTypes.LINK_TEXT)
+                    ?.getTextInNode(markdown)
+                    ?.toString()
+                    ?.removeSurrounding("[", "]")
+                    .orEmpty()
+
+                val token = parseTokenDestination(destination, linkLabel)
+
+                when {
+                    token != null -> token
+                    isImage ->
+                        RichSpanStyle.Image(
+                            model = destination,
+                            width = 0.sp,
+                            height = 0.sp,
+                        )
+                    else ->
+                        RichSpanStyle.Link(url = destination)
+                }
             }
 
             MarkdownElementTypes.CODE_SPAN ->
@@ -574,9 +586,39 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
         return when (richSpanStyle) {
             is RichSpanStyle.Link -> "[$text](${richSpanStyle.url})"
             is RichSpanStyle.Code -> "`$text`"
+            is RichSpanStyle.Token -> {
+                // Pseudo-link syntax: [label](trigger:triggerId:id)
+                val label = richSpanStyle.label.ifEmpty { text }
+                "[$label]($TokenDestinationPrefix${richSpanStyle.triggerId}:${richSpanStyle.id})"
+            }
             else -> text
         }
     }
+
+    /**
+     * Parses a link destination of the form `trigger:<triggerId>:<id>` into a [RichSpanStyle.Token].
+     * Returns `null` if the destination doesn't match the token shape.
+     */
+    @OptIn(ExperimentalRichTextApi::class)
+    private fun parseTokenDestination(
+        destination: String,
+        label: String,
+    ): RichSpanStyle.Token? {
+        if (!destination.startsWith(TokenDestinationPrefix)) return null
+        val payload = destination.removePrefix(TokenDestinationPrefix)
+        val separatorIndex = payload.indexOf(':')
+        if (separatorIndex <= 0) return null
+        val triggerId = payload.substring(0, separatorIndex)
+        val id = payload.substring(separatorIndex + 1)
+        if (triggerId.isEmpty() || id.isEmpty()) return null
+        return RichSpanStyle.Token(
+            triggerId = triggerId,
+            id = id,
+            label = label,
+        )
+    }
+
+    private const val TokenDestinationPrefix = "trigger:"
 
     /**
      * Returns the markdown line start text from the first [RichSpan].

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichTextEditor.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -235,6 +237,23 @@ public fun BasicRichTextEditor(
     }
 
     CompositionLocalProvider(LocalClipboard provides richClipboardManager) {
+        // Capture position on the innerTextField (the actual text content composable),
+        // not on the outer BasicTextField, so trigger-suggestion popups can anchor
+        // precisely at the text content's origin — not at the top of the decorated
+        // container (which for OutlinedRichTextEditor is ~16dp higher).
+        val positionCapturingDecorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit =
+            { innerTextField ->
+                decorationBox {
+                    androidx.compose.foundation.layout.Box(
+                        modifier = Modifier.onGloballyPositioned { coords ->
+                            state.textFieldWindowPosition = coords.positionInWindow()
+                        }
+                    ) {
+                        innerTextField()
+                    }
+                }
+            }
+
         BasicTextField(
             value = state.textFieldValue,
             onValueChange = {
@@ -297,7 +316,7 @@ public fun BasicRichTextEditor(
             },
             interactionSource = interactionSource,
             cursorBrush = cursorBrush,
-            decorationBox = decorationBox,
+            decorationBox = positionCapturingDecorationBox,
         )
     }
 }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/TriggerSuggestions.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/material3/TriggerSuggestions.kt
@@ -1,0 +1,291 @@
+package com.mohamedrejeb.richeditor.ui.material3
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichSpanStyle
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.model.trigger.Trigger
+
+/**
+ * Material 3 suggestions popup that renders while a matching [Trigger] is active.
+ *
+ * Reads [RichTextState.activeTriggerQuery]; shows nothing when no query is active
+ * or the trigger id does not match [triggerId]. Otherwise, anchors a [Popup] just
+ * below the caret with one row per item returned by [suggestions].
+ *
+ * Supports keyboard navigation while visible:
+ *  - `ArrowDown` / `ArrowUp` move the highlighted row;
+ *  - `Enter` commits the highlight;
+ *  - `Esc` cancels the active query (leaves the typed text in place).
+ *
+ * On commit (click or Enter), [onSelect] returns a [RichSpanStyle.Token]; the
+ * library then calls [RichTextState.insertToken] to splice it into the document
+ * as an atomic span followed by a trailing space.
+ *
+ * @param state The editor's rich text state.
+ * @param triggerId Id of the trigger this popup serves (e.g. `"mention"`).
+ * @param suggestions Pure function mapping the current query text to a list of candidates.
+ * @param onSelect Invoked when a row is committed; must return a [RichSpanStyle.Token]
+ * whose [RichSpanStyle.Token.triggerId] equals [triggerId] and whose
+ * [RichSpanStyle.Token.label] starts with the trigger's char.
+ * @param modifier Modifier applied to the popup's content container.
+ * @param verticalOffset Gap between the caret bottom and the popup top. Tune per decoration
+ * (e.g. `OutlinedRichTextEditor` needs more space than `BasicRichTextEditor`).
+ * @param containerColor Popup background. Defaults to [MaterialTheme.colorScheme.surface].
+ * @param contentColor Text color for rows. Defaults to [MaterialTheme.colorScheme.onSurface].
+ * @param highlightColor Background of the currently-highlighted row. Defaults to a translucent
+ * `surfaceVariant`.
+ * @param shape Shape of the popup container.
+ * @param maxVisibleItems Soft cap on rendered rows; content scrolls past this count.
+ * @param item Row composable for a single suggestion.
+ */
+@ExperimentalRichTextApi
+@Composable
+public fun <T> TriggerSuggestions(
+    state: RichTextState,
+    triggerId: String,
+    suggestions: (query: String) -> List<T>,
+    onSelect: (T) -> RichSpanStyle.Token,
+    modifier: Modifier = Modifier,
+    verticalOffset: Dp = 4.dp,
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    highlightColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    shape: Shape = RoundedCornerShape(8.dp),
+    maxVisibleItems: Int = 5,
+    item: @Composable (T) -> Unit,
+) {
+    val query = state.activeTriggerQuery
+    if (query == null || query.triggerId != triggerId) return
+
+    // Hold rendering until the caret rect has been resolved against the fresh text
+    // layout. Without this, the first frame after query activation renders the popup
+    // at (0,0) — the old layout's `getCursorRect` answer — before `onTextLayout`
+    // patches it one frame later. That produces a visible flicker.
+    //
+    // NOTE: a cursor rect has zero width (left == right), so we can't use Rect.isEmpty.
+    // A valid caret rect always has a positive `bottom`; Rect.Zero's bottom is 0.
+    val caretRect = query.caretRect ?: return
+    if (caretRect.bottom <= 0f) return
+
+    val items = remember(query.query) { suggestions(query.query) }
+    if (items.isEmpty()) return
+
+    // `highlighted` state is read inside the key handler — we pass the delegate reference
+    // via a separate ref so the handler always sees the latest value, never a stale closure.
+    val highlightedState = remember(query.query) { mutableStateOf(0) }
+    val safeHighlighted = highlightedState.value.coerceIn(0, items.lastIndex)
+
+    val density = LocalDensity.current
+    val verticalOffsetPx = remember(verticalOffset, density) { with(density) { verticalOffset.roundToPx() } }
+
+    val positionProvider = remember(caretRect, state.textFieldWindowPosition, verticalOffsetPx) {
+        CaretWindowPositionProvider(
+            textFieldWindowX = state.textFieldWindowPosition.x.toInt(),
+            textFieldWindowY = state.textFieldWindowPosition.y.toInt(),
+            caretX = caretRect.left.toInt(),
+            caretBottom = caretRect.bottom.toInt(),
+            verticalOffset = verticalOffsetPx,
+        )
+    }
+
+    val scrollState = rememberScrollState()
+    // Row y-positions (within the scrolling Column) and heights, populated via
+    // onGloballyPositioned as each row lays out. Used to scroll the highlighted
+    // row into view when the user navigates with arrow keys.
+    val rowYs = remember(items) { mutableStateListOf<Int>().apply { repeat(items.size) { add(0) } } }
+    val rowHeights = remember(items) { mutableStateListOf<Int>().apply { repeat(items.size) { add(0) } } }
+
+    // Install key handler while popup is visible. Consumes ↑/↓/Enter/Esc before they
+    // reach the text field. The lambda reads `highlightedState.value` afresh each call,
+    // so Enter always commits the CURRENTLY-highlighted row, not the one at install time.
+    DisposableEffect(state, triggerId, items) {
+        state.triggerKeyHandler = { event: KeyEvent ->
+            if (event.type != KeyEventType.KeyDown) {
+                false
+            } else when (event.key) {
+                Key.DirectionDown -> {
+                    if (items.isNotEmpty()) {
+                        highlightedState.value = (highlightedState.value + 1).mod(items.size)
+                    }
+                    true
+                }
+                Key.DirectionUp -> {
+                    if (items.isNotEmpty()) {
+                        highlightedState.value = ((highlightedState.value - 1) + items.size).mod(items.size)
+                    }
+                    true
+                }
+                Key.Enter, Key.NumPadEnter -> {
+                    val currentIndex = highlightedState.value.coerceIn(0, items.lastIndex)
+                    items.getOrNull(currentIndex)?.let { value ->
+                        commitSelection(state, triggerId, value, onSelect)
+                    }
+                    true
+                }
+                Key.Escape -> {
+                    state.cancelActiveTrigger()
+                    true
+                }
+                else -> false
+            }
+        }
+        onDispose {
+            if (state.triggerKeyHandler != null) {
+                state.triggerKeyHandler = null
+            }
+        }
+    }
+
+    // Keep the highlighted row visible. Scrolls only when the row is outside the
+    // current viewport; otherwise leaves the offset alone so the list stays stable.
+    LaunchedEffect(safeHighlighted) {
+        val rowY = rowYs.getOrNull(safeHighlighted) ?: return@LaunchedEffect
+        val rowH = rowHeights.getOrNull(safeHighlighted) ?: return@LaunchedEffect
+        val viewportH = scrollState.viewportSize.takeIf { it > 0 } ?: return@LaunchedEffect
+        val scrollOffset = scrollState.value
+        when {
+            rowY < scrollOffset -> scrollState.animateScrollTo(rowY)
+            rowY + rowH > scrollOffset + viewportH ->
+                scrollState.animateScrollTo(rowY + rowH - viewportH)
+        }
+    }
+
+    Popup(
+        popupPositionProvider = positionProvider,
+        onDismissRequest = { state.cancelActiveTrigger() },
+        properties = PopupProperties(focusable = false),
+    ) {
+        Surface(
+            shape = shape,
+            color = containerColor,
+            contentColor = contentColor,
+            tonalElevation = 3.dp,
+            shadowElevation = 6.dp,
+            modifier = modifier
+                .width(IntrinsicSize.Max)
+                .heightIn(max = 40.dp * maxVisibleItems),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(shape)
+                    .verticalScroll(scrollState),
+            ) {
+                items.forEachIndexed { index, value ->
+                    val isHighlighted = index == safeHighlighted
+                    val interaction = remember(index) { MutableInteractionSource() }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .onGloballyPositioned { coords ->
+                                if (index < rowYs.size) {
+                                    rowYs[index] = coords.positionInParent().y.toInt()
+                                    rowHeights[index] = coords.size.height
+                                }
+                            }
+                            .background(if (isHighlighted) highlightColor else Color.Transparent)
+                            .clickable(
+                                interactionSource = interaction,
+                                indication = null,
+                            ) {
+                                commitSelection(state, triggerId, value, onSelect)
+                            }
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                    ) {
+                        item(value)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@ExperimentalRichTextApi
+private fun <T> commitSelection(
+    state: RichTextState,
+    triggerId: String,
+    value: T,
+    onSelect: (T) -> RichSpanStyle.Token,
+) {
+    val token = onSelect(value)
+    require(token.triggerId == triggerId) {
+        "onSelect returned Token(triggerId='${token.triggerId}'), expected '$triggerId'"
+    }
+    state.insertToken(
+        triggerId = token.triggerId,
+        id = token.id,
+        label = token.label,
+    )
+}
+
+/**
+ * Anchors the popup at the caret in WINDOW coordinates (not relative to the
+ * popup's own anchorBounds) by using the text field's captured window position
+ * plus the caret's offset within the text layout. This avoids the
+ * anchorBounds-vs-text-content mismatch that causes the popup to overlap the
+ * query text when the editor has internal decoration padding (e.g. Outlined).
+ */
+private class CaretWindowPositionProvider(
+    private val textFieldWindowX: Int,
+    private val textFieldWindowY: Int,
+    private val caretX: Int,
+    private val caretBottom: Int,
+    private val verticalOffset: Int,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val x = (textFieldWindowX + caretX)
+            .coerceAtMost(windowSize.width - popupContentSize.width)
+            .coerceAtLeast(0)
+        val y = (textFieldWindowY + caretBottom + verticalOffset)
+            .coerceAtMost(windowSize.height - popupContentSize.height)
+            .coerceAtLeast(0)
+        return IntOffset(x, y)
+    }
+}

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/utils/AnnotatedStringExt.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/utils/AnnotatedStringExt.kt
@@ -121,7 +121,7 @@ internal fun AnnotatedString.Builder.append(
 ): Int {
     var index = startIndex
 
-    withStyle(richSpan.spanStyle.merge(richSpan.richSpanStyle.spanStyle(state.config))) {
+    withStyle(richSpan.spanStyle.merge(resolveRichSpanStyleStyle(state, richSpan.richSpanStyle))) {
         if (richSpan.richSpanStyle is RichSpanStyle.Image) {
             // Image owns a single placeholder char in the raw text;
             // appendCustomContent (via appendInlineContent) emits that
@@ -235,7 +235,7 @@ internal fun AnnotatedString.Builder.append(
 ): Int {
     var index = startIndex
 
-    withStyle(richSpan.spanStyle.merge(richSpan.richSpanStyle.spanStyle(state.config))) {
+    withStyle(richSpan.spanStyle.merge(resolveRichSpanStyleStyle(state, richSpan.richSpanStyle))) {
         richSpan.textRange = TextRange(index, index + richSpan.text.length)
 
         // Image owns a single placeholder char in the raw text;
@@ -267,4 +267,21 @@ internal fun AnnotatedString.Builder.append(
         }
     }
     return index
+}
+
+/**
+ * Resolve a span's render-time [SpanStyle], preferring the registered [Trigger]'s style
+ * for [RichSpanStyle.Token] spans when the trigger is known. Falls back to the style
+ * encoded on the [RichSpanStyle] itself (which, for Token, is a neutral default).
+ */
+@OptIn(ExperimentalRichTextApi::class)
+private fun resolveRichSpanStyleStyle(
+    state: RichTextState,
+    richSpanStyle: RichSpanStyle,
+): SpanStyle {
+    if (richSpanStyle is RichSpanStyle.Token) {
+        val trigger = state.findTrigger(richSpanStyle.triggerId)
+        if (trigger != null) return trigger.style(state.config)
+    }
+    return richSpanStyle.spanStyle(state.config)
 }

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/trigger/RichTextStateTokenTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/trigger/RichTextStateTokenTest.kt
@@ -1,0 +1,195 @@
+package com.mohamedrejeb.richeditor.model.trigger
+
+import androidx.compose.ui.text.TextRange
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichSpanStyle
+import com.mohamedrejeb.richeditor.model.RichTextState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextStateTokenTest {
+
+    private fun newState() = RichTextState().apply {
+        registerTrigger(Trigger(id = "mention", char = '@'))
+        registerTrigger(Trigger(id = "hashtag", char = '#'))
+    }
+
+    @Test
+    fun `registerTrigger rejects duplicate char`() {
+        val state = RichTextState()
+        state.registerTrigger(Trigger(id = "mention", char = '@'))
+        assertFailsWith<IllegalArgumentException> {
+            state.registerTrigger(Trigger(id = "other", char = '@'))
+        }
+    }
+
+    @Test
+    fun `registerTrigger replaces existing id`() {
+        val state = RichTextState()
+        state.registerTrigger(Trigger(id = "mention", char = '@'))
+        state.registerTrigger(Trigger(id = "mention", char = '@', maxQueryLength = 10))
+        assertEquals(1, state.triggers.size)
+        assertEquals(10, state.triggers.first().maxQueryLength)
+    }
+
+    @Test
+    fun `unregisterTrigger clears active query for that id`() {
+        val state = newState()
+        state.addTextAtIndex(0, "@moh")
+        assertNotNull(state.activeTriggerQuery)
+        state.unregisterTrigger("mention")
+        assertNull(state.activeTriggerQuery)
+    }
+
+    @Test
+    fun `typing trigger produces active query`() {
+        val state = newState()
+        state.addTextAtIndex(0, "@")
+        val q = state.activeTriggerQuery
+        assertNotNull(q)
+        assertEquals("mention", q.triggerId)
+        assertEquals("", q.query)
+    }
+
+    @Test
+    fun `typing trigger then chars updates query`() {
+        val state = newState()
+        state.addTextAtIndex(0, "@moh")
+        assertEquals("moh", state.activeTriggerQuery?.query)
+    }
+
+    @Test
+    fun `typing stop char cancels query`() {
+        val state = newState()
+        state.addTextAtIndex(0, "@moh ")
+        assertNull(state.activeTriggerQuery)
+    }
+
+    @Test
+    fun `cancelActiveTrigger dismisses without changing text`() {
+        val state = newState()
+        state.addTextAtIndex(0, "@moh")
+        assertNotNull(state.activeTriggerQuery)
+        state.cancelActiveTrigger()
+        assertNull(state.activeTriggerQuery)
+        assertEquals("@moh", state.toText())
+    }
+
+    @Test
+    fun `insertToken replaces query with token plus trailing space`() {
+        val state = newState()
+        state.addTextAtIndex(0, "Hi @moh")
+        state.insertToken(triggerId = "mention", id = "u1", label = "@mohamed")
+
+        assertEquals("Hi @mohamed ", state.toText())
+        assertNull(state.activeTriggerQuery)
+        // Caret after the trailing space
+        assertEquals(TextRange("Hi @mohamed ".length), state.selection)
+    }
+
+    @Test
+    fun `insertToken creates atomic Token span in tree`() {
+        val state = newState()
+        state.addTextAtIndex(0, "Hi @moh")
+        state.insertToken(triggerId = "mention", id = "u1", label = "@mohamed")
+
+        // The span covering "@mohamed" must be Token with atomic=true.
+        val span = state.getSpanAtOffset(3) // position of '@'
+        assertNotNull(span)
+        val style = span.richSpanStyle
+        assertTrue(style is RichSpanStyle.Token, "Expected Token span, got $style")
+        assertEquals("mention", style.triggerId)
+        assertEquals("u1", style.id)
+        assertEquals("@mohamed", style.label)
+        assertTrue(style.isAtomic)
+    }
+
+    @Test
+    fun `insertToken without active query throws`() {
+        val state = newState()
+        state.addTextAtIndex(0, "Hi ")
+        assertFailsWith<IllegalStateException> {
+            state.insertToken("mention", "u1", "@mohamed")
+        }
+    }
+
+    @Test
+    fun `insertToken with wrong triggerId throws`() {
+        val state = newState()
+        state.addTextAtIndex(0, "@moh")
+        assertFailsWith<IllegalStateException> {
+            state.insertToken("hashtag", "t1", "@mohamed")
+        }
+    }
+
+    @Test
+    fun `insertToken with label missing trigger char throws`() {
+        val state = newState()
+        state.addTextAtIndex(0, "@moh")
+        assertFailsWith<IllegalArgumentException> {
+            state.insertToken("mention", "u1", "mohamed")
+        }
+    }
+
+    @Test
+    fun `hashtag trigger works alongside mention`() {
+        val state = newState()
+        state.addTextAtIndex(0, "See #rel")
+        val q = state.activeTriggerQuery
+        assertNotNull(q)
+        assertEquals("hashtag", q.triggerId)
+        assertEquals("rel", q.query)
+
+        state.insertToken("hashtag", "release-1", "#release")
+        assertEquals("See #release ", state.toText())
+    }
+
+    @Test
+    fun `insertToken in middle of multi-paragraph document keeps trailing space in the right paragraph`() {
+        // Regression for the bug where the trailing space ended up at the start of paragraph 2
+        // when the token was inserted at the end of paragraph 1.
+        val state = newState()
+        // Two paragraphs; the @ query is at the end of paragraph 1 before the paragraph break.
+        state.setText("Hi @moh\nSecond paragraph")
+        // Move caret to the end of "@moh" so activeTriggerQuery is set up for commit.
+        state.selection = TextRange("Hi @moh".length)
+        assertNotNull(state.activeTriggerQuery, "expected active query at end of first paragraph")
+
+        state.insertToken("mention", "u1", "@mohamed")
+
+        // Raw text must have the token + space inside paragraph 1, then \n, then paragraph 2.
+        val expected = "Hi @mohamed \nSecond paragraph"
+        assertEquals(expected, state.toText())
+    }
+
+    @Test
+    fun `token renders with trigger custom style not hardcoded link color`() {
+        // Regression: previously Token.spanStyle returned linkColor regardless of trigger.
+        // Now the render path consults the trigger's style(config) lambda.
+        val state = RichTextState()
+        val customColor = androidx.compose.ui.graphics.Color(0xFF8E24AA)
+        state.registerTrigger(
+            Trigger(
+                id = "mention",
+                char = '@',
+                style = { androidx.compose.ui.text.SpanStyle(color = customColor) },
+            )
+        )
+        state.addTextAtIndex(0, "@")
+        state.insertToken("mention", "u1", "@alice")
+
+        val span = state.getRichSpanByTextIndex(0)
+        require(span != null)
+        // The RichSpan's explicit spanStyle should carry the trigger's custom color.
+        assertEquals(customColor, span.spanStyle.color)
+    }
+}
+
+/** Helper to look up a span by raw-text offset in tests. Uses the module-internal lookup. */
+private fun RichTextState.getSpanAtOffset(offset: Int): com.mohamedrejeb.richeditor.model.RichSpan? =
+    getRichSpanByTextIndex(offset)

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/trigger/TriggerDetectorTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/trigger/TriggerDetectorTest.kt
@@ -1,0 +1,216 @@
+package com.mohamedrejeb.richeditor.model.trigger
+
+import androidx.compose.ui.text.TextRange
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalRichTextApi::class)
+class TriggerDetectorTest {
+
+    private val mention = Trigger(id = "mention", char = '@')
+    private val hashtag = Trigger(id = "hashtag", char = '#')
+    private val command = Trigger(id = "command", char = '/')
+
+    @Test
+    fun `single trigger char yields empty query`() {
+        val result = detectActiveTrigger(
+            text = "@",
+            caretOffset = 1,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertEquals("mention", result?.triggerId)
+        assertEquals("", result?.query)
+        assertEquals(TextRange(0, 1), result?.range)
+    }
+
+    @Test
+    fun `trigger followed by chars yields full query`() {
+        val result = detectActiveTrigger(
+            text = "@moh",
+            caretOffset = 4,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertEquals("moh", result?.query)
+        assertEquals(TextRange(0, 4), result?.range)
+    }
+
+    @Test
+    fun `stop char cancels query`() {
+        val result = detectActiveTrigger(
+            text = "@moh ",
+            caretOffset = 5,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `requireWordBoundary blocks mid-word activation`() {
+        val result = detectActiveTrigger(
+            text = "foo@bar",
+            caretOffset = 7,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `requireWordBoundary allows activation after space`() {
+        val result = detectActiveTrigger(
+            text = "foo @bar",
+            caretOffset = 8,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertEquals("bar", result?.query)
+        assertEquals(TextRange(4, 8), result?.range)
+    }
+
+    @Test
+    fun `requireWordBoundary allows activation at text start`() {
+        val result = detectActiveTrigger(
+            text = "@alice",
+            caretOffset = 6,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertEquals("alice", result?.query)
+    }
+
+    @Test
+    fun `requireWordBoundary false allows mid-word activation`() {
+        val relaxed = Trigger(id = "mention", char = '@', requireWordBoundary = false)
+        val result = detectActiveTrigger(
+            text = "foo@bar",
+            caretOffset = 7,
+            triggers = listOf(relaxed),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertEquals("bar", result?.query)
+    }
+
+    @Test
+    fun `multiple triggers dispatch to the matching char`() {
+        val triggers = listOf(mention, hashtag, command)
+
+        val resultHash = detectActiveTrigger(
+            text = "post #release",
+            caretOffset = 13,
+            triggers = triggers,
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertEquals("hashtag", resultHash?.triggerId)
+        assertEquals("release", resultHash?.query)
+
+        val resultCmd = detectActiveTrigger(
+            text = "do /hel",
+            caretOffset = 7,
+            triggers = triggers,
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertEquals("command", resultCmd?.triggerId)
+        assertEquals("hel", resultCmd?.query)
+    }
+
+    @Test
+    fun `maxQueryLength abandons overlong queries`() {
+        val capped = Trigger(id = "mention", char = '@', maxQueryLength = 3)
+        val result = detectActiveTrigger(
+            text = "@abcdef",
+            caretOffset = 7,
+            triggers = listOf(capped),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `empty triggers list always yields null`() {
+        val result = detectActiveTrigger(
+            text = "@anything",
+            caretOffset = 9,
+            triggers = emptyList(),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `caret before trigger char yields null`() {
+        val result = detectActiveTrigger(
+            text = "@moh",
+            caretOffset = 0,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `caret past stop char after trigger yields null`() {
+        val result = detectActiveTrigger(
+            text = "@moh and more",
+            caretOffset = 13,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `suppressed range suppresses re-activation while caret inside`() {
+        val result = detectActiveTrigger(
+            text = "@moh",
+            caretOffset = 3,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = TextRange(0, 4),
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `suppressed range does not block after caret leaves`() {
+        // Caret is past the suppressed range — but a stop char is needed to
+        // end the token; this case ensures suppression clears when outside.
+        val result = detectActiveTrigger(
+            text = "@moh after",
+            caretOffset = 5, // just after the space
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = TextRange(0, 4),
+        )
+        assertNull(result) // blocked by stop char, not by suppression
+    }
+
+    @Test
+    fun `newline acts as stop char by default`() {
+        val result = detectActiveTrigger(
+            text = "@moh\n",
+            caretOffset = 5,
+            triggers = listOf(mention),
+            textLayoutResult = null,
+            suppressedRange = null,
+        )
+        assertNull(result)
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserTokenTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserTokenTest.kt
@@ -1,0 +1,96 @@
+package com.mohamedrejeb.richeditor.parser.html
+
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichSpanStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextStateHtmlParserTokenTest {
+
+    @Test
+    fun `token serializes to span with data attributes`() {
+        val input = """<p>Hi <span data-trigger="mention" data-id="u1">@mohamed</span></p>"""
+        val state = RichTextStateHtmlParser.encode(input)
+        val html = RichTextStateHtmlParser.decode(state)
+
+        assertTrue(
+            html.contains("""<span data-trigger="mention" data-id="u1">""") &&
+                (html.contains("@mohamed</span>") || html.contains("&commat;mohamed</span>")),
+            "Expected data-trigger span with label in output, got: $html"
+        )
+    }
+
+    @Test
+    fun `token parses to Token rich span style`() {
+        val input = """<p><span data-trigger="mention" data-id="u1">@mohamed</span></p>"""
+        val state = RichTextStateHtmlParser.encode(input)
+
+        val span = state.getRichSpanByTextIndex(0)
+        val style = span?.richSpanStyle
+        assertTrue(style is RichSpanStyle.Token)
+        assertEquals("mention", style.triggerId)
+        assertEquals("u1", style.id)
+        assertEquals("@mohamed", style.label)
+        assertTrue(style.isAtomic)
+    }
+
+    @Test
+    fun `multiple same-trigger tokens round-trip`() {
+        val input = """<p>CC <span data-trigger="mention" data-id="u1">@alice</span> and <span data-trigger="mention" data-id="u2">@bob</span></p>"""
+        val state = RichTextStateHtmlParser.encode(input)
+        val html = RichTextStateHtmlParser.decode(state)
+
+        assertTrue(html.contains("""data-trigger="mention" data-id="u1""""), "Missing first token: $html")
+        assertTrue(html.contains("""data-trigger="mention" data-id="u2""""), "Missing second token: $html")
+    }
+
+    @Test
+    fun `multiple different-trigger tokens round-trip`() {
+        val input = """<p><span data-trigger="mention" data-id="u1">@alice</span> <span data-trigger="hashtag" data-id="release">#release</span></p>"""
+        val state = RichTextStateHtmlParser.encode(input)
+        val html = RichTextStateHtmlParser.decode(state)
+
+        assertTrue(html.contains("""data-trigger="mention""""), "Missing mention: $html")
+        assertTrue(html.contains("""data-trigger="hashtag""""), "Missing hashtag: $html")
+    }
+
+    @Test
+    fun `unknown triggerId still parses and re-serializes`() {
+        val input = """<p><span data-trigger="unknown" data-id="x1">@ghost</span></p>"""
+        val state = RichTextStateHtmlParser.encode(input)
+        val html = RichTextStateHtmlParser.decode(state)
+
+        assertTrue(html.contains("""data-trigger="unknown""""), "Should preserve unknown trigger: $html")
+    }
+
+    @Test
+    fun `span without data-trigger is plain span not token`() {
+        val input = """<p><span class="foo">hi</span></p>"""
+        val state = RichTextStateHtmlParser.encode(input)
+        val span = state.getRichSpanByTextIndex(0)
+        assertTrue(span?.richSpanStyle !is RichSpanStyle.Token)
+    }
+
+    @Test
+    fun `malformed span with data-trigger but no data-id is plain`() {
+        val input = """<p><span data-trigger="mention">@x</span></p>"""
+        val state = RichTextStateHtmlParser.encode(input)
+        val span = state.getRichSpanByTextIndex(0)
+        assertTrue(span?.richSpanStyle !is RichSpanStyle.Token)
+    }
+
+    @Test
+    fun `token id with quotes is escaped on output`() {
+        // Direct construction exercises the escape path without relying on parser input shape.
+        val state = com.mohamedrejeb.richeditor.model.RichTextState()
+        state.setHtml("""<p><span data-trigger="mention" data-id='a"b'>@x</span></p>""")
+        val html = state.toHtml()
+        assertTrue(
+            html.contains("""data-id="a&quot;b"""") || html.contains("""data-id='a"b'"""),
+            "id quote must be escaped or preserved safely: $html"
+        )
+        assertTrue(!html.contains("""data-id="a"b""""), "raw unescaped quote broke attribute: $html")
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParserTokenTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParserTokenTest.kt
@@ -1,0 +1,81 @@
+package com.mohamedrejeb.richeditor.parser.markdown
+
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichSpanStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextStateMarkdownParserTokenTest {
+
+    @Test
+    fun `token decodes to trigger link syntax`() {
+        val state = com.mohamedrejeb.richeditor.model.RichTextState()
+        state.setMarkdown("Hi [@mohamed](trigger:mention:u1)")
+
+        val span = state.getRichSpanByTextIndex(3) // position of '@'
+        val style = span?.richSpanStyle
+        assertTrue(style is RichSpanStyle.Token, "Got: $style")
+        assertEquals("mention", style.triggerId)
+        assertEquals("u1", style.id)
+        assertEquals("@mohamed", style.label)
+    }
+
+    @Test
+    fun `token round-trips through markdown`() {
+        val input = "Hi [@mohamed](trigger:mention:u1)"
+        val state = com.mohamedrejeb.richeditor.model.RichTextState()
+        state.setMarkdown(input)
+        val out = state.toMarkdown()
+
+        assertTrue(
+            out.contains("[@mohamed](trigger:mention:u1)"),
+            "Expected trigger link in output: $out"
+        )
+    }
+
+    @Test
+    fun `regular link is not confused with token`() {
+        val state = com.mohamedrejeb.richeditor.model.RichTextState()
+        state.setMarkdown("[click](https://example.com)")
+
+        val span = state.getRichSpanByTextIndex(0)
+        val style = span?.richSpanStyle
+        assertTrue(style is RichSpanStyle.Link)
+        assertEquals("https://example.com", style.url)
+    }
+
+    @Test
+    fun `hashtag trigger round-trips`() {
+        val input = "See [#release](trigger:hashtag:release-1)"
+        val state = com.mohamedrejeb.richeditor.model.RichTextState()
+        state.setMarkdown(input)
+        val out = state.toMarkdown()
+
+        assertTrue(out.contains("[#release](trigger:hashtag:release-1)"), "Got: $out")
+    }
+
+    @Test
+    fun `malformed trigger destination is not treated as token`() {
+        // Missing id portion — invariant: we must not fabricate a Token with an empty id.
+        val state = com.mohamedrejeb.richeditor.model.RichTextState()
+        state.setMarkdown("[x](trigger:mention:)")
+
+        val span = state.getRichSpanByTextIndex(0)
+        val style = span?.richSpanStyle
+        assertTrue(style !is RichSpanStyle.Token, "Malformed payload must not become a Token, got $style")
+    }
+
+    @Test
+    fun `id with underscores and hyphens parses correctly`() {
+        val state = com.mohamedrejeb.richeditor.model.RichTextState()
+        state.setMarkdown("[@user_name](trigger:mention:user-id_1)")
+
+        val span = state.getRichSpanByTextIndex(0)
+        val style = span?.richSpanStyle
+        assertTrue(style is RichSpanStyle.Token)
+        assertEquals("user-id_1", style.id)
+        assertEquals("@user_name", style.label)
+    }
+}

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/home/HomeScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/home/HomeScreen.kt
@@ -19,6 +19,7 @@ fun HomeScreen(
     navigateToHtmlEditor: () -> Unit,
     navigateToMarkdownEditor: () -> Unit,
     navigateToSlack: () -> Unit,
+    navigateToMentions: () -> Unit,
 ) {
     val richTextState = rememberRichTextState()
 
@@ -91,6 +92,14 @@ fun HomeScreen(
                     onClick = navigateToSlack,
                 ) {
                     Text("Slack Clone Demo")
+                }
+            }
+
+            item {
+                Button(
+                    onClick = navigateToMentions,
+                ) {
+                    Text("Mentions / Triggers Demo")
                 }
             }
         }

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/mentions/MentionsSampleScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/mentions/MentionsSampleScreen.kt
@@ -1,0 +1,250 @@
+package com.mohamedrejeb.richeditor.sample.common.mentions
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichSpanStyle
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.model.trigger.Trigger
+import com.mohamedrejeb.richeditor.ui.material3.OutlinedRichTextEditor
+import com.mohamedrejeb.richeditor.ui.material3.TriggerSuggestions
+
+/** One sample user / tag / command, keyed by stable id. */
+private data class MentionUser(val id: String, val name: String, val handle: String)
+private data class HashtagSuggestion(val slug: String)
+private data class SlashCommand(val id: String, val label: String, val description: String)
+
+private val sampleUsers = listOf(
+    MentionUser("u-alice", "Alice Johnson", "@alice"),
+    MentionUser("u-bob", "Bob Smith", "@bob"),
+    MentionUser("u-carol", "Carol Diaz", "@carol"),
+    MentionUser("u-david", "David Lee", "@david"),
+    MentionUser("u-mohamed", "Mohamed Rejeb", "@mohamed"),
+)
+
+private val sampleHashtags = listOf(
+    "release", "rfc", "design", "bug", "good-first-issue", "discussion",
+)
+
+private val slashCommands = listOf(
+    SlashCommand("heading", "/heading", "Insert a heading"),
+    SlashCommand("code", "/code", "Insert a code block"),
+    SlashCommand("divider", "/divider", "Insert a horizontal rule"),
+    SlashCommand("date", "/date", "Insert today's date"),
+)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalRichTextApi::class)
+@Composable
+fun MentionsSampleScreen(
+    navigateBack: () -> Unit,
+) {
+    val state = rememberRichTextState()
+
+    LaunchedEffect(Unit) {
+        state.registerTrigger(
+            Trigger(
+                id = "mention",
+                char = '@',
+                style = { SpanStyle(color = Color(0xFF1E88E5), fontWeight = FontWeight.Medium) },
+            )
+        )
+        state.registerTrigger(
+            Trigger(
+                id = "hashtag",
+                char = '#',
+                style = { SpanStyle(color = Color(0xFF8E24AA), fontWeight = FontWeight.Medium) },
+            )
+        )
+        state.registerTrigger(
+            Trigger(
+                id = "command",
+                char = '/',
+                style = { SpanStyle(color = Color(0xFF00897B), fontFamily = FontFamily.Monospace) },
+            )
+        )
+        // Pre-populate one token of each kind so the styling is visible without typing.
+        state.setMarkdown(
+            "Hi [@mohamed](trigger:mention:u-mohamed), see " +
+                "[#release](trigger:hashtag:release) and " +
+                "[/heading](trigger:command:heading). " +
+                "Type @, # or / to try it yourself.\n"
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Mentions / Triggers Demo") },
+                navigationIcon = {
+                    IconButton(onClick = navigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        modifier = Modifier.fillMaxSize(),
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .windowInsetsPadding(WindowInsets.ime)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Box {
+                OutlinedRichTextEditor(
+                    state = state,
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 120.dp),
+                )
+
+                // Popup for each trigger — only renders when its triggerId is active.
+                TriggerSuggestions(
+                    state = state,
+                    triggerId = "mention",
+                    suggestions = { query ->
+                        sampleUsers.filter {
+                            query.isEmpty() ||
+                                it.handle.contains(query, ignoreCase = true) ||
+                                it.name.contains(query, ignoreCase = true)
+                        }
+                    },
+                    onSelect = { user ->
+                        RichSpanStyle.Token(
+                            triggerId = "mention",
+                            id = user.id,
+                            label = user.handle,
+                        )
+                    },
+                    item = { user ->
+                        Column {
+                            Text(user.handle, fontWeight = FontWeight.Medium)
+                            Text(user.name, style = MaterialTheme.typography.bodySmall)
+                        }
+                    },
+                )
+
+                TriggerSuggestions(
+                    state = state,
+                    triggerId = "hashtag",
+                    suggestions = { query ->
+                        sampleHashtags.filter { query.isEmpty() || it.contains(query, ignoreCase = true) }
+                    },
+                    onSelect = { tag ->
+                        RichSpanStyle.Token(
+                            triggerId = "hashtag",
+                            id = tag,
+                            label = "#$tag",
+                        )
+                    },
+                    item = { tag ->
+                        Text("#$tag")
+                    },
+                )
+
+                TriggerSuggestions(
+                    state = state,
+                    triggerId = "command",
+                    suggestions = { query ->
+                        slashCommands.filter { query.isEmpty() || it.label.contains(query, ignoreCase = true) }
+                    },
+                    onSelect = { cmd ->
+                        RichSpanStyle.Token(
+                            triggerId = "command",
+                            id = cmd.id,
+                            label = cmd.label,
+                        )
+                    },
+                    item = { cmd ->
+                        Column {
+                            Text(cmd.label, fontFamily = FontFamily.Monospace)
+                            Text(cmd.description, style = MaterialTheme.typography.bodySmall)
+                        }
+                    },
+                )
+            }
+
+            ExportPanel(
+                title = "HTML",
+                content = remember(state.annotatedString) { state.toHtml() },
+            )
+
+            ExportPanel(
+                title = "Markdown",
+                content = remember(state.annotatedString) { state.toMarkdown() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExportPanel(
+    title: String,
+    content: String,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Spacer(Modifier.height(6.dp))
+        val scroll = rememberScrollState()
+        Text(
+            text = content,
+            fontFamily = FontFamily.Monospace,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 140.dp)
+                .verticalScroll(scroll),
+        )
+    }
+}

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/navigation/NavGraph.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/navigation/NavGraph.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.rememberNavController
 import com.mohamedrejeb.richeditor.sample.common.home.HomeScreen
 import com.mohamedrejeb.richeditor.sample.common.htmleditor.HtmlEditorContent
 import com.mohamedrejeb.richeditor.sample.common.markdowneditor.MarkdownEditorContent
+import com.mohamedrejeb.richeditor.sample.common.mentions.MentionsSampleScreen
 import com.mohamedrejeb.richeditor.sample.common.richeditor.RichEditorScreen
 import com.mohamedrejeb.richeditor.sample.common.slack.SlackDemoScreen
 
@@ -15,6 +16,7 @@ private const val RICH_EDITOR_ROUTE = "richEditor"
 private const val HTML_EDITOR_ROUTE = "htmlEditor"
 private const val MARKDOWN_EDITOR_ROUTE = "markdownEditor"
 private const val SLACK_ROUTE = "slack"
+private const val MENTIONS_ROUTE = "mentions"
 
 @Composable
 fun NavGraph() {
@@ -29,7 +31,8 @@ fun NavGraph() {
                 navigateToRichEditor = { navController.navigate(RICH_EDITOR_ROUTE) },
                 navigateToHtmlEditor = { navController.navigate(HTML_EDITOR_ROUTE) },
                 navigateToMarkdownEditor = { navController.navigate(MARKDOWN_EDITOR_ROUTE) },
-                navigateToSlack = { navController.navigate(SLACK_ROUTE) }
+                navigateToSlack = { navController.navigate(SLACK_ROUTE) },
+                navigateToMentions = { navController.navigate(MENTIONS_ROUTE) },
             )
         }
 
@@ -53,6 +56,12 @@ fun NavGraph() {
 
         composable(SLACK_ROUTE) {
             SlackDemoScreen(
+                navigateBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(MENTIONS_ROUTE) {
+            MentionsSampleScreen(
                 navigateBack = { navController.popBackStack() }
             )
         }


### PR DESCRIPTION
Generic single-character trigger infrastructure: mentions (@), hashtags (#), slash commands (/), or any user-registered trigger. State-owned registration, atomic token spans with full HTML/Markdown round-trip, and an optional Material3 suggestions popup with keyboard navigation.

Public API (all @ExperimentalRichTextApi):
- Trigger, TriggerQuery, RichSpanStyle.Token, DefaultTriggerStopChars
- RichTextState: registerTrigger, unregisterTrigger, triggers, activeTriggerQuery, insertToken, cancelActiveTrigger
- material3.TriggerSuggestions composable (caret-anchored popup with up/down arrow navigation, Enter commit, Esc cancel, auto-scroll)

Internal changes:
- Add RichSpanStyle.isAtomic (default false); override in Image and Token
- Generalize 7 `is RichSpanStyle.Image` checks across RichSpan and RichTextState to `.isAtomic`
- Render path resolves Token style from the registered trigger at draw time
- HTML parser: `<span data-trigger data-id>` round-trip, plus attribute value escaping for all spans
- Markdown parser: `[label](trigger:triggerId:id)` round-trip
- BasicRichTextEditor wraps innerTextField with a position-capturing Box so popups anchor to the true text-content origin (works across decorations)

Sample: new MentionsSampleScreen demonstrating mention/hashtag/command triggers with live HTML and Markdown export.

Closes: #45 #252 