### PR TITLE
fix: preserve dot-aligned list indent while keeping prefix visible

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
@@ -96,13 +96,20 @@ internal class OrderedList private constructor(
         return style
     }
 
-    private fun getNewParagraphStyle() =
-        ParagraphStyle(
-            textIndent = TextIndent(
-                firstLine = (indent * level).sp,
-                restLine = ((indent * level) + startTextWidth.value).sp
-            )
-        )
+    private fun getNewParagraphStyle(): ParagraphStyle {
+        val base = (indent * level).toFloat()
+        val prefix = startTextWidth.value
+        // Keep HTML-style alignment (prefix lives in the indent "gutter", dots align vertically)
+        // when there is room; fall back to placing the prefix inside so it stays visible when
+        // the indent is smaller than the prefix width.
+        val textIndent =
+            if (base >= prefix)
+                TextIndent(firstLine = (base - prefix).sp, restLine = base.sp)
+            else
+                TextIndent(firstLine = base.sp, restLine = (base + prefix).sp)
+
+        return ParagraphStyle(textIndent = textIndent)
+    }
 
     override var startRichSpan: RichSpan =
         getNewStartRichSpan()

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
@@ -75,13 +75,20 @@ internal class UnorderedList private constructor(
         return style
     }
 
-    private fun getNewParagraphStyle() =
-        ParagraphStyle(
-            textIndent = TextIndent(
-                firstLine = (indent * level).sp,
-                restLine = ((indent * level) + startTextWidth.value).sp
-            )
-        )
+    private fun getNewParagraphStyle(): ParagraphStyle {
+        val base = (indent * level).toFloat()
+        val prefix = startTextWidth.value
+        // Keep HTML-style alignment (prefix lives in the indent "gutter") when there is room;
+        // fall back to placing the prefix inside so it stays visible when the indent is smaller
+        // than the prefix width.
+        val textIndent =
+            if (base >= prefix)
+                TextIndent(firstLine = (base - prefix).sp, restLine = base.sp)
+            else
+                TextIndent(firstLine = base.sp, restLine = (base + prefix).sp)
+
+        return ParagraphStyle(textIndent = textIndent)
+    }
 
     @OptIn(ExperimentalRichTextApi::class)
     override var startRichSpan: RichSpan =

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedListIndentTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedListIndentTest.kt
@@ -1,0 +1,71 @@
+package com.mohamedrejeb.richeditor.paragraph.type
+
+import androidx.compose.ui.unit.sp
+import com.mohamedrejeb.richeditor.model.RichTextConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class OrderedListIndentTest {
+
+    private fun config(indent: Int): RichTextConfig =
+        RichTextConfig(updateText = {}).apply { orderedListIndent = indent }
+
+    @Test
+    fun indentLargerThanPrefixAlignsDots() {
+        val config = config(indent = 38)
+        val list = OrderedList(number = 1, config = config, startTextWidth = 20.sp)
+
+        val textIndent = list.getStyle(config).textIndent
+        assertNotNull(textIndent)
+
+        // 38 >= 20: classic hanging indent — prefix sits in the gutter, dots align.
+        assertEquals(18f, textIndent.firstLine.value)
+        assertEquals(38f, textIndent.restLine.value)
+        assertTrue(textIndent.firstLine.value < textIndent.restLine.value)
+    }
+
+    @Test
+    fun indentSmallerThanPrefixKeepsPrefixVisible() {
+        val config = config(indent = 10)
+        val list = OrderedList(number = 1, config = config, startTextWidth = 50.sp)
+
+        val textIndent = list.getStyle(config).textIndent
+        assertNotNull(textIndent)
+
+        // 10 < 50: prefix would not fit in the gutter, so it moves inside.
+        assertEquals(10f, textIndent.firstLine.value)
+        assertEquals(60f, textIndent.restLine.value)
+        assertTrue(textIndent.firstLine.value >= 0f) // no clipping
+    }
+
+    @Test
+    fun zeroIndentKeepsPrefixVisible() {
+        val config = config(indent = 0)
+        val list = OrderedList(number = 1, config = config, startTextWidth = 20.sp)
+
+        val textIndent = list.getStyle(config).textIndent
+        assertNotNull(textIndent)
+
+        // Edge case: indent = 0 (from the original bug report).
+        assertEquals(0f, textIndent.firstLine.value)
+        assertEquals(20f, textIndent.restLine.value)
+    }
+
+    @Test
+    fun deeperLevelGrowsTheGutterAndRestoresDotAlignment() {
+        val config = config(indent = 10)
+        // Level 2 multiplies base (10*2 = 20), which is still < prefix (50) → fallback.
+        val listLevel2 = OrderedList(number = 1, config = config, startTextWidth = 50.sp, initialLevel = 2)
+        val level2Indent = listLevel2.getStyle(config).textIndent!!
+        assertEquals(20f, level2Indent.firstLine.value)
+        assertEquals(70f, level2Indent.restLine.value)
+
+        // At level 6, base (60) >= prefix (50) → we flip back to the dot-aligned layout.
+        val listLevel6 = OrderedList(number = 1, config = config, startTextWidth = 50.sp, initialLevel = 6)
+        val level6Indent = listLevel6.getStyle(config).textIndent!!
+        assertEquals(10f, level6Indent.firstLine.value)
+        assertEquals(60f, level6Indent.restLine.value)
+    }
+}


### PR DESCRIPTION
PR #636 moved the list prefix inside the indent gutter so it no longer gets clipped when the configured indent is smaller than the prefix width. That fix also regressed the classic HTML-style layout where "1." / "10." / "11." have their dots aligned vertically.

Switch OrderedList and UnorderedList to a hybrid TextIndent:
- when indent * level >= prefix width, use the classic hanging indent (firstLine = base - prefix, restLine = base) so dots align as before;
- otherwise, fall back to the PR #636 formula so the prefix stays on screen (firstLine = base, restLine = base + prefix).

Also fixes:
- #296 — listIndent = 0 hides the number
- #299 — Ordered vs unordered indent inconsistency
- #622 — listIndent config change invisible

Adds OrderedListIndentTest covering the gutter-fits case, the small indent fallback, the indent = 0 edge case, and the level-based transition between the two modes.