### PR TITLE
feat: add ListMarkerStyleBehavior to control list marker style inheritance

### DIFF
--- a/docs/ordered_unordered_lists.md
+++ b/docs/ordered_unordered_lists.md
@@ -7,6 +7,7 @@
   - [Ordered Lists](#ordered-lists)
   - [Unordered Lists](#unordered-lists)
 - [List Indentation](#list-indentation)
+- [List Marker Style](#list-marker-style)
 - [Common Operations](#common-operations)
   - [Default Values](#default-values)
   - [Keyboard Shortcuts](#keyboard-shortcuts)
@@ -106,6 +107,38 @@ richTextState.config.orderedListIndent = 20
 richTextState.config.unorderedListIndent = 20
 ```
 
+## List Marker Style
+
+> **Note:** This API is marked `@ExperimentalRichTextApi` and may change in a future release.
+
+You can control how list markers (`•`, `1.`, etc.) inherit styles from the list item's text using `ListMarkerStyleBehavior`:
+
+```kotlin
+// Default: marker inherits typography from the item's text but drops decorations.
+richTextState.config.listMarkerStyleBehavior = ListMarkerStyleBehavior.InheritFromText
+
+// Alternative: every marker renders with the default span style regardless of content.
+richTextState.config.listMarkerStyleBehavior = ListMarkerStyleBehavior.AlwaysDefault
+```
+
+With `InheritFromText` (the default), markers match the paragraph's typography so they stay visually aligned with the text. This matches Google Docs behavior:
+
+| Attribute | Applied to marker |
+|---|---|
+| `color` | yes |
+| `fontSize` | yes |
+| `fontWeight` (bold) | yes |
+| `fontStyle` (italic) | yes |
+| `fontFamily` | yes |
+| `letterSpacing` | yes |
+| `textDecoration` (underline, strikethrough) | no |
+| `background` (highlight) | no |
+| `baselineShift` (super/subscript) | no |
+| `shadow` | no |
+| `textGeometricTransform` | no |
+
+Use `AlwaysDefault` when you want bullets that look identical no matter how the line is formatted (for example, editors that style markers entirely through a separate theme).
+
 ## Common Operations
 
 ### Default Values
@@ -119,6 +152,7 @@ By default, the Rich Text Editor uses these configurations:
   - Second level: `◦` (circle)
   - Third level: `▪` (square)
 - List Indentation: 38
+- List Marker Style: `ListMarkerStyleBehavior.InheritFromText`
 - Exit List on Empty Item: `true` (configurable via `richTextState.config.exitListOnEmptyItem`)
 
 ### Keyboard Shortcuts

--- a/richeditor-compose/api/android/richeditor-compose.api
+++ b/richeditor-compose/api/android/richeditor-compose.api
@@ -129,6 +129,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun getLinkColor-0d7_KjU ()J
 	public final fun getLinkTextDecoration ()Landroidx/compose/ui/text/style/TextDecoration;
 	public final fun getListIndent ()I
+	public final fun getListMarkerStyleBehavior ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
 	public final fun getOrderedListIndent ()I
 	public final fun getOrderedListStyleType ()Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;
 	public final fun getPreserveStyleOnEmptyLine ()Z
@@ -141,6 +142,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun setLinkColor-8_81llA (J)V
 	public final fun setLinkTextDecoration (Landroidx/compose/ui/text/style/TextDecoration;)V
 	public final fun setListIndent (I)V
+	public final fun setListMarkerStyleBehavior (Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;)V
 	public final fun setOrderedListIndent (I)V
 	public final fun setOrderedListStyleType (Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;)V
 	public final fun setPreserveStyleOnEmptyLine (Z)V
@@ -317,6 +319,14 @@ public final class com/mohamedrejeb/richeditor/model/trigger/TriggerQuery {
 	public final fun getTriggerId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior : java/lang/Enum {
+	public static final field AlwaysDefault Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public static final field InheritFromText Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public static fun values ()[Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
 }
 
 public abstract interface class com/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType {

--- a/richeditor-compose/api/desktop/richeditor-compose.api
+++ b/richeditor-compose/api/desktop/richeditor-compose.api
@@ -129,6 +129,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun getLinkColor-0d7_KjU ()J
 	public final fun getLinkTextDecoration ()Landroidx/compose/ui/text/style/TextDecoration;
 	public final fun getListIndent ()I
+	public final fun getListMarkerStyleBehavior ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
 	public final fun getOrderedListIndent ()I
 	public final fun getOrderedListStyleType ()Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;
 	public final fun getPreserveStyleOnEmptyLine ()Z
@@ -141,6 +142,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun setLinkColor-8_81llA (J)V
 	public final fun setLinkTextDecoration (Landroidx/compose/ui/text/style/TextDecoration;)V
 	public final fun setListIndent (I)V
+	public final fun setListMarkerStyleBehavior (Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;)V
 	public final fun setOrderedListIndent (I)V
 	public final fun setOrderedListStyleType (Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;)V
 	public final fun setPreserveStyleOnEmptyLine (Z)V
@@ -317,6 +319,14 @@ public final class com/mohamedrejeb/richeditor/model/trigger/TriggerQuery {
 	public final fun getTriggerId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior : java/lang/Enum {
+	public static final field AlwaysDefault Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public static final field InheritFromText Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public static fun values ()[Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
 }
 
 public abstract interface class com/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType {

--- a/richeditor-compose/api/richeditor-compose.klib.api
+++ b/richeditor-compose/api/richeditor-compose.klib.api
@@ -14,6 +14,17 @@ open annotation class com.mohamedrejeb.richeditor.annotation/InternalRichTextApi
     constructor <init>() // com.mohamedrejeb.richeditor.annotation/InternalRichTextApi.<init>|<init>(){}[0]
 }
 
+final enum class com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior : kotlin/Enum<com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior> { // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior|null[0]
+    enum entry AlwaysDefault // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior.AlwaysDefault|null[0]
+    enum entry InheritFromText // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior.InheritFromText|null[0]
+
+    final val entries // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior> // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior> // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior.values|values#static(){}[0]
+}
+
 final enum class com.mohamedrejeb.richeditor.ui/UndoBehavior : kotlin/Enum<com.mohamedrejeb.richeditor.ui/UndoBehavior> { // com.mohamedrejeb.richeditor.ui/UndoBehavior|null[0]
     enum entry Disabled // com.mohamedrejeb.richeditor.ui/UndoBehavior.Disabled|null[0]
     enum entry Enabled // com.mohamedrejeb.richeditor.ui/UndoBehavior.Enabled|null[0]
@@ -273,6 +284,9 @@ final class com.mohamedrejeb.richeditor.model/RichTextConfig { // com.mohamedrej
     final var listIndent // com.mohamedrejeb.richeditor.model/RichTextConfig.listIndent|{}listIndent[0]
         final fun <get-listIndent>(): kotlin/Int // com.mohamedrejeb.richeditor.model/RichTextConfig.listIndent.<get-listIndent>|<get-listIndent>(){}[0]
         final fun <set-listIndent>(kotlin/Int) // com.mohamedrejeb.richeditor.model/RichTextConfig.listIndent.<set-listIndent>|<set-listIndent>(kotlin.Int){}[0]
+    final var listMarkerStyleBehavior // com.mohamedrejeb.richeditor.model/RichTextConfig.listMarkerStyleBehavior|{}listMarkerStyleBehavior[0]
+        final fun <get-listMarkerStyleBehavior>(): com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior // com.mohamedrejeb.richeditor.model/RichTextConfig.listMarkerStyleBehavior.<get-listMarkerStyleBehavior>|<get-listMarkerStyleBehavior>(){}[0]
+        final fun <set-listMarkerStyleBehavior>(com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior) // com.mohamedrejeb.richeditor.model/RichTextConfig.listMarkerStyleBehavior.<set-listMarkerStyleBehavior>|<set-listMarkerStyleBehavior>(com.mohamedrejeb.richeditor.paragraph.type.ListMarkerStyleBehavior){}[0]
     final var orderedListIndent // com.mohamedrejeb.richeditor.model/RichTextConfig.orderedListIndent|{}orderedListIndent[0]
         final fun <get-orderedListIndent>(): kotlin/Int // com.mohamedrejeb.richeditor.model/RichTextConfig.orderedListIndent.<get-orderedListIndent>|<get-orderedListIndent>(){}[0]
         final fun <set-orderedListIndent>(kotlin/Int) // com.mohamedrejeb.richeditor.model/RichTextConfig.orderedListIndent.<set-orderedListIndent>|<set-orderedListIndent>(kotlin.Int){}[0]

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextConfig.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextConfig.kt
@@ -2,6 +2,8 @@ package com.mohamedrejeb.richeditor.model
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextDecoration
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.paragraph.type.ListMarkerStyleBehavior
 import com.mohamedrejeb.richeditor.paragraph.type.OrderedListStyleType
 import com.mohamedrejeb.richeditor.paragraph.type.UnorderedListStyleType
 
@@ -93,6 +95,25 @@ public class RichTextConfig internal constructor(
         }
 
     public var orderedListStyleType: OrderedListStyleType = DefaultOrderedListStyleType
+        set(value) {
+            field = value
+            updateText()
+        }
+
+    /**
+     * Controls how list markers ("•", "1.", etc.) inherit span styles from the
+     * list item's text.
+     *
+     * Default is [ListMarkerStyleBehavior.InheritFromText], which keeps bold /
+     * italic / color / font size on the marker but drops underline, strikethrough,
+     * background, baseline shift, shadow, and geometric transforms. Matches
+     * Google Docs.
+     *
+     * Set to [ListMarkerStyleBehavior.AlwaysDefault] to render every marker with
+     * the default span style regardless of the item's content.
+     */
+    @ExperimentalRichTextApi
+    public var listMarkerStyleBehavior: ListMarkerStyleBehavior = ListMarkerStyleBehavior.InheritFromText
         set(value) {
             field = value
             updateText()

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -2248,7 +2248,7 @@ public class RichTextState internal constructor(
                 }
 
                 withStyle(richParagraph.paragraphStyle.merge(richParagraph.type.getStyle(config))) {
-                    withStyle(richParagraph.getStartTextSpanStyle() ?: RichSpanStyle.DefaultSpanStyle) {
+                    withStyle(richParagraph.getListMarkerSpanStyle(config.listMarkerStyleBehavior)) {
                         append(richParagraph.type.startText)
                     }
                     val richParagraphStartTextLength = richParagraph.type.startText.length
@@ -4687,7 +4687,7 @@ public class RichTextState internal constructor(
             richParagraphList.fastForEachIndexed { i, richParagraph ->
                 withStyle(richParagraph.paragraphStyle.merge(richParagraph.type.getStyle(config))) {
                     withStyle(
-                        richParagraph.getStartTextSpanStyle() ?: RichSpanStyle.DefaultSpanStyle
+                        richParagraph.getListMarkerSpanStyle(config.listMarkerStyleBehavior)
                     ) {
                         append(richParagraph.type.startText)
                     }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/RichParagraph.kt
@@ -1,5 +1,6 @@
 package com.mohamedrejeb.richeditor.paragraph
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextRange
@@ -8,7 +9,9 @@ import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.util.fastForEachReversed
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichSpan
+import com.mohamedrejeb.richeditor.model.RichSpanStyle
 import com.mohamedrejeb.richeditor.paragraph.type.DefaultParagraph
+import com.mohamedrejeb.richeditor.paragraph.type.ListMarkerStyleBehavior
 import com.mohamedrejeb.richeditor.paragraph.type.ParagraphType
 import com.mohamedrejeb.richeditor.paragraph.type.ParagraphType.Companion.startText
 import com.mohamedrejeb.richeditor.ui.test.getRichTextStyleTreeRepresentation
@@ -179,6 +182,28 @@ internal class RichParagraph(
     }
 
     fun isNotBlank(ignoreStartRichSpan: Boolean = true): Boolean = !isBlank(ignoreStartRichSpan)
+
+    /**
+     * Compute the [SpanStyle] used for the list marker (the "•", "1.", etc.
+     * prefix appended by [ParagraphType.startText]) based on the chosen
+     * [behavior] and the paragraph's content.
+     *
+     * See [ListMarkerStyleBehavior] for what is kept versus stripped.
+     */
+    @OptIn(ExperimentalRichTextApi::class)
+    fun getListMarkerSpanStyle(behavior: ListMarkerStyleBehavior): SpanStyle =
+        when (behavior) {
+            ListMarkerStyleBehavior.InheritFromText ->
+                getStartTextSpanStyle()?.copy(
+                    textDecoration = null,
+                    background = Color.Unspecified,
+                    baselineShift = null,
+                    shadow = null,
+                    textGeometricTransform = null,
+                ) ?: RichSpanStyle.DefaultSpanStyle
+            ListMarkerStyleBehavior.AlwaysDefault ->
+                RichSpanStyle.DefaultSpanStyle
+        }
 
     @OptIn(ExperimentalRichTextApi::class)
     fun getStartTextSpanStyle(): SpanStyle? {

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior.kt
@@ -1,0 +1,30 @@
+package com.mohamedrejeb.richeditor.paragraph.type
+
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+
+/**
+ * Controls how the prefix of a list item ("•", "1.", etc.) inherits span styles
+ * from the paragraph's text.
+ *
+ * @see com.mohamedrejeb.richeditor.model.RichTextConfig.listMarkerStyleBehavior
+ */
+@ExperimentalRichTextApi
+public enum class ListMarkerStyleBehavior {
+    /**
+     * The marker inherits the paragraph's typography (color, font size, font
+     * family, font weight, font style, letter spacing) but drops decorations
+     * that are tied to the text content itself (underline, strikethrough,
+     * background highlight, baseline shift, shadow, geometric transforms).
+     *
+     * Default. Matches the behavior of Google Docs and similar editors: bold
+     * and font size apply to the bullet, but underline does not.
+     */
+    InheritFromText,
+
+    /**
+     * The marker always renders with the default span style, regardless of the
+     * paragraph's first span. Useful for editors that want every bullet to
+     * look the same no matter what formatting is applied to the text.
+     */
+    AlwaysDefault,
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/ListMarkerStyleBehaviorTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/ListMarkerStyleBehaviorTest.kt
@@ -1,0 +1,161 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.sp
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.paragraph.RichParagraph
+import com.mohamedrejeb.richeditor.paragraph.type.ListMarkerStyleBehavior
+import com.mohamedrejeb.richeditor.paragraph.type.ParagraphType.Companion.startText
+import com.mohamedrejeb.richeditor.paragraph.type.UnorderedList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for issue #668 — list markers should not inherit every
+ * inline style from the first span of the list item.
+ *
+ * Default ([ListMarkerStyleBehavior.InheritFromText]):
+ *   - Keep: color, fontSize, fontWeight, fontStyle, fontFamily, letterSpacing
+ *   - Strip: textDecoration, background, baselineShift, shadow, textGeometricTransform
+ *
+ * [ListMarkerStyleBehavior.AlwaysDefault] strips everything — useful for editors
+ * that want every bullet identical regardless of content.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class ListMarkerStyleBehaviorTest {
+
+    private fun listState(spanStyle: SpanStyle): RichTextState =
+        RichTextState(
+            listOf(
+                RichParagraph(type = UnorderedList()).also { paragraph ->
+                    paragraph.children.add(
+                        RichSpan(
+                            text = "Item",
+                            paragraph = paragraph,
+                            spanStyle = spanStyle,
+                        )
+                    )
+                }
+            )
+        )
+
+    /**
+     * Return the style actually applied to the paragraph's marker ("• ")
+     * in the rendered annotated string. The marker is at offset 0 with
+     * length equal to startText.length.
+     */
+    private fun markerStyleOf(state: RichTextState): SpanStyle {
+        val markerLength = state.richParagraphList.first().type.startText.length
+        assertTrue(markerLength > 0, "expected non-empty marker")
+        val markerRange = TextRange(0, markerLength)
+        val matching = state.annotatedString.spanStyles
+            .filter { it.start <= markerRange.min && it.end >= markerRange.max }
+            .fold(SpanStyle()) { acc, range -> acc.merge(range.item) }
+        return matching
+    }
+
+    // --- InheritFromText defaults ---
+
+    @Test
+    fun markerInheritsBoldByDefault() {
+        val state = listState(SpanStyle(fontWeight = FontWeight.Bold))
+        assertEquals(FontWeight.Bold, markerStyleOf(state).fontWeight)
+    }
+
+    @Test
+    fun markerInheritsItalicByDefault() {
+        val state = listState(SpanStyle(fontStyle = FontStyle.Italic))
+        assertEquals(FontStyle.Italic, markerStyleOf(state).fontStyle)
+    }
+
+    @Test
+    fun markerInheritsColorByDefault() {
+        val state = listState(SpanStyle(color = Color.Red))
+        assertEquals(Color.Red, markerStyleOf(state).color)
+    }
+
+    @Test
+    fun markerInheritsFontSizeByDefault() {
+        val state = listState(SpanStyle(fontSize = 24.sp))
+        assertEquals(24.sp, markerStyleOf(state).fontSize)
+    }
+
+    @Test
+    fun markerDoesNotInheritUnderline() {
+        val state = listState(SpanStyle(textDecoration = TextDecoration.Underline))
+        assertNull(markerStyleOf(state).textDecoration)
+    }
+
+    @Test
+    fun markerDoesNotInheritStrikethrough() {
+        val state = listState(SpanStyle(textDecoration = TextDecoration.LineThrough))
+        assertNull(markerStyleOf(state).textDecoration)
+    }
+
+    @Test
+    fun markerDoesNotInheritBackground() {
+        val state = listState(SpanStyle(background = Color.Yellow))
+        assertEquals(Color.Unspecified, markerStyleOf(state).background)
+    }
+
+    @Test
+    fun markerDoesNotInheritBaselineShift() {
+        val state = listState(SpanStyle(baselineShift = BaselineShift.Superscript))
+        assertNull(markerStyleOf(state).baselineShift)
+    }
+
+    @Test
+    fun markerKeepsBoldButNotUnderlineWhenBothApplied() {
+        val state = listState(
+            SpanStyle(
+                fontWeight = FontWeight.Bold,
+                textDecoration = TextDecoration.Underline,
+            )
+        )
+        val style = markerStyleOf(state)
+        assertEquals(FontWeight.Bold, style.fontWeight)
+        assertNull(style.textDecoration)
+    }
+
+    // --- AlwaysDefault strips everything ---
+
+    @Test
+    fun alwaysDefaultDropsBold() {
+        val state = listState(SpanStyle(fontWeight = FontWeight.Bold))
+        state.config.listMarkerStyleBehavior = ListMarkerStyleBehavior.AlwaysDefault
+        assertNull(markerStyleOf(state).fontWeight)
+    }
+
+    @Test
+    fun alwaysDefaultDropsColorAndFontSize() {
+        val state = listState(SpanStyle(color = Color.Red, fontSize = 30.sp))
+        state.config.listMarkerStyleBehavior = ListMarkerStyleBehavior.AlwaysDefault
+        val style = markerStyleOf(state)
+        assertEquals(Color.Unspecified, style.color)
+        assertEquals(androidx.compose.ui.unit.TextUnit.Unspecified, style.fontSize)
+    }
+
+    @Test
+    fun switchingBehaviorUpdatesMarker() {
+        val state = listState(SpanStyle(fontWeight = FontWeight.Bold))
+
+        // Default: marker is bold.
+        assertEquals(FontWeight.Bold, markerStyleOf(state).fontWeight)
+
+        // Switch to AlwaysDefault: marker loses bold.
+        state.config.listMarkerStyleBehavior = ListMarkerStyleBehavior.AlwaysDefault
+        assertNull(markerStyleOf(state).fontWeight)
+
+        // Switch back: marker regains bold.
+        state.config.listMarkerStyleBehavior = ListMarkerStyleBehavior.InheritFromText
+        assertEquals(FontWeight.Bold, markerStyleOf(state).fontWeight)
+    }
+}


### PR DESCRIPTION
- Introduced `ListMarkerStyleBehavior` enum with `InheritFromText` and `AlwaysDefault` options.
- Updated `RichTextConfig` to expose `listMarkerStyleBehavior` for controlling marker styles.
- Enhanced marker rendering logic in `RichParagraph` to handle the configurable behavior.

Closes: #668