### PR TITLE
feat: add ListPrefixAlignment for customizable list marker alignment

### DIFF
--- a/docs/ordered_unordered_lists.md
+++ b/docs/ordered_unordered_lists.md
@@ -7,6 +7,7 @@
   - [Ordered Lists](#ordered-lists)
   - [Unordered Lists](#unordered-lists)
 - [List Indentation](#list-indentation)
+- [List Prefix Alignment](#list-prefix-alignment)
 - [List Marker Style](#list-marker-style)
 - [Common Operations](#common-operations)
   - [Default Values](#default-values)
@@ -107,6 +108,32 @@ richTextState.config.orderedListIndent = 20
 richTextState.config.unorderedListIndent = 20
 ```
 
+## List Prefix Alignment
+
+> **Note:** This API is marked `@ExperimentalRichTextApi` and may change in a future release.
+
+You can control where the list marker (`1.`, `10.`, `•`, ...) sits relative to the
+indent "gutter" using `ListPrefixAlignment`:
+
+```kotlin
+// Default: HTML-style — the marker sits inside the gutter and ends at the content
+// start, so "1." and "10." have their dots aligned vertically.
+richTextState.config.listPrefixAlignment = ListPrefixAlignment.End
+
+// Alternative: every item's marker starts at the same left edge, giving a uniform
+// left edge even when item widths differ (e.g. "1." vs "10.").
+richTextState.config.listPrefixAlignment = ListPrefixAlignment.Start
+```
+
+| Alignment | Layout | Example |
+|---|---|---|
+| `End` (default) | marker right-aligned to content start, dots align vertically | `` 1.`` / ``10.`` / ``11.`` — dots stacked |
+| `Start` | marker left-aligned to the indent origin, marker left edges stack | ``1.`` / ``10. `` / ``11. `` — numbers stacked |
+
+If the configured indent is smaller than the marker width (for example
+`orderedListIndent = 0`), `End` automatically falls back to `Start` for that
+paragraph so the marker stays visible.
+
 ## List Marker Style
 
 > **Note:** This API is marked `@ExperimentalRichTextApi` and may change in a future release.
@@ -152,6 +179,7 @@ By default, the Rich Text Editor uses these configurations:
   - Second level: `◦` (circle)
   - Third level: `▪` (square)
 - List Indentation: 38
+- List Prefix Alignment: `ListPrefixAlignment.End` (HTML-style, dots aligned)
 - List Marker Style: `ListMarkerStyleBehavior.InheritFromText`
 - Exit List on Empty Item: `true` (configurable via `richTextState.config.exitListOnEmptyItem`)
 

--- a/richeditor-compose/api/desktop/richeditor-compose.api
+++ b/richeditor-compose/api/desktop/richeditor-compose.api
@@ -130,6 +130,8 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun getLinkTextDecoration ()Landroidx/compose/ui/text/style/TextDecoration;
 	public final fun getListIndent ()I
 	public final fun getListMarkerStyleBehavior ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public final fun getListPrefixAlignment ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
+	public final fun getMaxImageWidth-XSAIIZE ()J
 	public final fun getOrderedListIndent ()I
 	public final fun getOrderedListStyleType ()Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;
 	public final fun getPreserveStyleOnEmptyLine ()Z
@@ -143,6 +145,8 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun setLinkTextDecoration (Landroidx/compose/ui/text/style/TextDecoration;)V
 	public final fun setListIndent (I)V
 	public final fun setListMarkerStyleBehavior (Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;)V
+	public final fun setListPrefixAlignment (Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;)V
+	public final fun setMaxImageWidth--R2X_6o (J)V
 	public final fun setOrderedListIndent (I)V
 	public final fun setOrderedListStyleType (Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;)V
 	public final fun setPreserveStyleOnEmptyLine (Z)V
@@ -327,6 +331,14 @@ public final class com/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBeh
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
 	public static fun values ()[Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+}
+
+public final class com/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment : java/lang/Enum {
+	public static final field End Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
+	public static final field Start Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
+	public static fun values ()[Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
 }
 
 public abstract interface class com/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType {

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextConfig.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextConfig.kt
@@ -2,8 +2,10 @@ package com.mohamedrejeb.richeditor.model
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.paragraph.type.ListMarkerStyleBehavior
+import com.mohamedrejeb.richeditor.paragraph.type.ListPrefixAlignment
 import com.mohamedrejeb.richeditor.paragraph.type.OrderedListStyleType
 import com.mohamedrejeb.richeditor.paragraph.type.UnorderedListStyleType
 
@@ -114,6 +116,24 @@ public class RichTextConfig internal constructor(
      */
     @ExperimentalRichTextApi
     public var listMarkerStyleBehavior: ListMarkerStyleBehavior = ListMarkerStyleBehavior.InheritFromText
+        set(value) {
+            field = value
+            updateText()
+        }
+
+    /**
+     * Controls where list markers ("1.", "10.", "•", ...) sit relative to the
+     * indent gutter in ordered and unordered lists.
+     *
+     * Default is [ListPrefixAlignment.End], which matches HTML: the marker sits
+     * inside the gutter and ends at the content start, so "1." and "10." have
+     * their dots aligned vertically.
+     *
+     * Set to [ListPrefixAlignment.Start] to make every item's marker start at
+     * the same left edge instead.
+     */
+    @ExperimentalRichTextApi
+    public var listPrefixAlignment: ListPrefixAlignment = ListPrefixAlignment.End
         set(value) {
             field = value
             updateText()

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment.kt
@@ -1,0 +1,27 @@
+package com.mohamedrejeb.richeditor.paragraph.type
+
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+
+/**
+ * Controls where the list marker ("1.", "10.", "•", ...) sits relative to the
+ * indent gutter in ordered and unordered lists.
+ */
+@ExperimentalRichTextApi
+public enum class ListPrefixAlignment {
+    /**
+     * HTML default: the marker sits inside the indent gutter and ends at the
+     * content start, so markers of different widths are right-aligned
+     * (the dots of "1.", "10.", and "11." line up vertically).
+     *
+     * When the configured indent is smaller than the marker width, the library
+     * falls back to [Start] for that paragraph so the marker stays visible.
+     */
+    End,
+
+    /**
+     * Every list item's marker starts at the same left edge; the text after the
+     * marker therefore sits at a slightly different x for single- vs double-digit
+     * numbers. Useful when a uniform left edge is preferred over dot alignment.
+     */
+    Start,
+}

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
@@ -12,12 +12,14 @@ import com.mohamedrejeb.richeditor.model.RichSpan
 import com.mohamedrejeb.richeditor.model.RichTextConfig
 import com.mohamedrejeb.richeditor.paragraph.RichParagraph
 
+@OptIn(ExperimentalRichTextApi::class)
 internal class OrderedList private constructor(
     number: Int,
     initialIndent: Int = DefaultListIndent,
     startTextWidth: TextUnit = 0.sp,
     initialLevel: Int = 1,
     initialStyleType: OrderedListStyleType = DefaultOrderedListStyleType,
+    initialPrefixAlignment: ListPrefixAlignment = ListPrefixAlignment.End,
     /**
      * The start number for the first item in this list group.
      * Defaults to 1. When > 1, the HTML output includes `start="N"` on the `<ol>` tag.
@@ -48,6 +50,7 @@ internal class OrderedList private constructor(
         startTextWidth = startTextWidth,
         initialLevel = initialLevel,
         initialStyleType = config.orderedListStyleType,
+        initialPrefixAlignment = config.listPrefixAlignment,
         startFrom = startFrom,
     )
 
@@ -81,6 +84,12 @@ internal class OrderedList private constructor(
             startRichSpan = getNewStartRichSpan(startRichSpan.textRange)
         }
 
+    private var prefixAlignment = initialPrefixAlignment
+        set(value) {
+            field = value
+            style = getNewParagraphStyle()
+        }
+
     private var style: ParagraphStyle =
         getNewParagraphStyle()
 
@@ -93,17 +102,23 @@ internal class OrderedList private constructor(
             styleType = config.orderedListStyleType
         }
 
+        if (config.listPrefixAlignment != prefixAlignment) {
+            prefixAlignment = config.listPrefixAlignment
+        }
+
         return style
     }
 
     private fun getNewParagraphStyle(): ParagraphStyle {
         val base = (indent * level).toFloat()
         val prefix = startTextWidth.value
-        // Keep HTML-style alignment (prefix lives in the indent "gutter", dots align vertically)
-        // when there is room; fall back to placing the prefix inside so it stays visible when
-        // the indent is smaller than the prefix width.
+        // End: HTML-style alignment — prefix lives in the indent "gutter" and dots align
+        // vertically, but fall back to Start when the indent is too small so the prefix
+        // doesn't get clipped off the left edge.
+        // Start: every item's prefix starts at the indent origin, giving a uniform left edge.
+        val useEnd = prefixAlignment == ListPrefixAlignment.End && base >= prefix
         val textIndent =
-            if (base >= prefix)
+            if (useEnd)
                 TextIndent(firstLine = (base - prefix).sp, restLine = base.sp)
             else
                 TextIndent(firstLine = base.sp, restLine = (base + prefix).sp)
@@ -135,6 +150,7 @@ internal class OrderedList private constructor(
             startTextWidth = startTextWidth,
             initialLevel = level,
             initialStyleType = styleType,
+            initialPrefixAlignment = prefixAlignment,
         )
 
     override fun copy(): ParagraphType =
@@ -144,6 +160,7 @@ internal class OrderedList private constructor(
             startTextWidth = startTextWidth,
             initialLevel = level,
             initialStyleType = styleType,
+            initialPrefixAlignment = prefixAlignment,
         )
 
     override fun equals(other: Any?): Boolean {
@@ -155,6 +172,7 @@ internal class OrderedList private constructor(
         if (startTextWidth != other.startTextWidth) return false
         if (level != other.level) return false
         if (styleType != other.styleType) return false
+        if (prefixAlignment != other.prefixAlignment) return false
 
         return true
     }
@@ -166,6 +184,7 @@ internal class OrderedList private constructor(
         result = 31 * result + startTextWidth.hashCode()
         result = 31 * result + level
         result = 31 * result + styleType.hashCode()
+        result = 31 * result + prefixAlignment.hashCode()
         return result
     }
 }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
@@ -12,11 +12,13 @@ import com.mohamedrejeb.richeditor.model.RichSpan
 import com.mohamedrejeb.richeditor.model.RichTextConfig
 import com.mohamedrejeb.richeditor.paragraph.RichParagraph
 
+@OptIn(ExperimentalRichTextApi::class)
 internal class UnorderedList private constructor(
     initialIndent: Int = DefaultListIndent,
     startTextWidth: TextUnit = 0.sp,
     initialLevel: Int = 1,
     initialStyleType: UnorderedListStyleType = DefaultUnorderedListStyleType,
+    initialPrefixAlignment: ListPrefixAlignment = ListPrefixAlignment.End,
 ): ParagraphType, ConfigurableStartTextWidth, ConfigurableListLevel {
 
     constructor(
@@ -33,6 +35,7 @@ internal class UnorderedList private constructor(
         initialIndent = config.unorderedListIndent,
         initialLevel = initialLevel,
         initialStyleType = config.unorderedListStyleType,
+        initialPrefixAlignment = config.listPrefixAlignment,
     )
 
     override var startTextWidth: TextUnit = startTextWidth
@@ -60,6 +63,12 @@ internal class UnorderedList private constructor(
             startRichSpan = getNewStartRichSpan()
         }
 
+    private var prefixAlignment = initialPrefixAlignment
+        set(value) {
+            field = value
+            style = getNewParagraphStyle()
+        }
+
     private var style: ParagraphStyle =
         getNewParagraphStyle()
 
@@ -72,17 +81,22 @@ internal class UnorderedList private constructor(
             styleType = config.unorderedListStyleType
         }
 
+        if (config.listPrefixAlignment != prefixAlignment) {
+            prefixAlignment = config.listPrefixAlignment
+        }
+
         return style
     }
 
     private fun getNewParagraphStyle(): ParagraphStyle {
         val base = (indent * level).toFloat()
         val prefix = startTextWidth.value
-        // Keep HTML-style alignment (prefix lives in the indent "gutter") when there is room;
-        // fall back to placing the prefix inside so it stays visible when the indent is smaller
-        // than the prefix width.
+        // End: HTML-style alignment — prefix lives in the indent "gutter"; fall back to
+        // Start when the indent is too small so the prefix doesn't get clipped.
+        // Start: every item's prefix starts at the indent origin.
+        val useEnd = prefixAlignment == ListPrefixAlignment.End && base >= prefix
         val textIndent =
-            if (base >= prefix)
+            if (useEnd)
                 TextIndent(firstLine = (base - prefix).sp, restLine = base.sp)
             else
                 TextIndent(firstLine = base.sp, restLine = (base + prefix).sp)
@@ -121,6 +135,7 @@ internal class UnorderedList private constructor(
             startTextWidth = startTextWidth,
             initialLevel = level,
             initialStyleType = styleType,
+            initialPrefixAlignment = prefixAlignment,
         )
 
     override fun copy(): ParagraphType =
@@ -129,6 +144,7 @@ internal class UnorderedList private constructor(
             startTextWidth = startTextWidth,
             initialLevel = level,
             initialStyleType = styleType,
+            initialPrefixAlignment = prefixAlignment,
         )
 
     override fun equals(other: Any?): Boolean {
@@ -139,6 +155,7 @@ internal class UnorderedList private constructor(
         if (startTextWidth != other.startTextWidth) return false
         if (level != other.level) return false
         if (styleType != other.styleType) return false
+        if (prefixAlignment != other.prefixAlignment) return false
 
         return true
     }
@@ -148,6 +165,7 @@ internal class UnorderedList private constructor(
         result = 31 * result + startTextWidth.hashCode()
         result = 31 * result + level
         result = 31 * result + styleType.hashCode()
+        result = 31 * result + prefixAlignment.hashCode()
         return result
     }
 }

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedListIndentTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedListIndentTest.kt
@@ -1,16 +1,25 @@
 package com.mohamedrejeb.richeditor.paragraph.type
 
 import androidx.compose.ui.unit.sp
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichTextConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalRichTextApi::class)
 class OrderedListIndentTest {
 
-    private fun config(indent: Int): RichTextConfig =
-        RichTextConfig(updateText = {}).apply { orderedListIndent = indent }
+    private fun config(
+        indent: Int,
+        alignment: ListPrefixAlignment = ListPrefixAlignment.End,
+    ): RichTextConfig =
+        RichTextConfig(updateText = {}).apply {
+            orderedListIndent = indent
+            unorderedListIndent = indent
+            listPrefixAlignment = alignment
+        }
 
     @Test
     fun indentLargerThanPrefixAlignsDots() {
@@ -67,5 +76,50 @@ class OrderedListIndentTest {
         val level6Indent = listLevel6.getStyle(config).textIndent!!
         assertEquals(10f, level6Indent.firstLine.value)
         assertEquals(60f, level6Indent.restLine.value)
+    }
+
+    @Test
+    fun startAlignmentForcesUniformLeftEdgeEvenWhenGutterFits() {
+        val config = config(indent = 38, alignment = ListPrefixAlignment.Start)
+        val list = OrderedList(number = 1, config = config, startTextWidth = 20.sp)
+
+        val textIndent = list.getStyle(config).textIndent
+        assertNotNull(textIndent)
+
+        // Start alignment ignores the "gutter fits" case: prefix starts at the indent origin.
+        assertEquals(38f, textIndent.firstLine.value)
+        assertEquals(58f, textIndent.restLine.value)
+    }
+
+    @Test
+    fun changingAlignmentOnConfigUpdatesExistingList() {
+        val config = config(indent = 38, alignment = ListPrefixAlignment.End)
+        val list = OrderedList(number = 1, config = config, startTextWidth = 20.sp)
+
+        // Starts in End (classic dot-aligned).
+        val endIndent = list.getStyle(config).textIndent!!
+        assertEquals(18f, endIndent.firstLine.value)
+        assertEquals(38f, endIndent.restLine.value)
+
+        // Flip the config at runtime; the existing list picks it up on the next getStyle.
+        config.listPrefixAlignment = ListPrefixAlignment.Start
+        val startIndent = list.getStyle(config).textIndent!!
+        assertEquals(38f, startIndent.firstLine.value)
+        assertEquals(58f, startIndent.restLine.value)
+    }
+
+    @Test
+    fun unorderedListRespectsAlignment() {
+        val endConfig = config(indent = 38, alignment = ListPrefixAlignment.End)
+        val endList = UnorderedList(config = endConfig).apply { startTextWidth = 12.sp }
+        val endIndent = endList.getStyle(endConfig).textIndent!!
+        assertEquals(26f, endIndent.firstLine.value)
+        assertEquals(38f, endIndent.restLine.value)
+
+        val startConfig = config(indent = 38, alignment = ListPrefixAlignment.Start)
+        val startList = UnorderedList(config = startConfig).apply { startTextWidth = 12.sp }
+        val startIndent = startList.getStyle(startConfig).textIndent!!
+        assertEquals(38f, startIndent.firstLine.value)
+        assertEquals(50f, startIndent.restLine.value)
     }
 }

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/home/HomeScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/home/HomeScreen.kt
@@ -21,6 +21,7 @@ fun HomeScreen(
     navigateToSlack: () -> Unit,
     navigateToMentions: () -> Unit,
     navigateToUndoRedo: () -> Unit,
+    navigateToListsConfig: () -> Unit,
 ) {
     val richTextState = rememberRichTextState()
 
@@ -109,6 +110,14 @@ fun HomeScreen(
                     onClick = navigateToUndoRedo,
                 ) {
                     Text("Undo / Redo Demo")
+                }
+            }
+
+            item {
+                Button(
+                    onClick = navigateToListsConfig,
+                ) {
+                    Text("Lists Configuration Demo")
                 }
             }
         }

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/listsconfig/ListsConfigSampleScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/listsconfig/ListsConfigSampleScreen.kt
@@ -1,0 +1,228 @@
+package com.mohamedrejeb.richeditor.sample.common.listsconfig
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.paragraph.type.ListPrefixAlignment
+import com.mohamedrejeb.richeditor.paragraph.type.OrderedListStyleType
+import com.mohamedrejeb.richeditor.paragraph.type.UnorderedListStyleType
+import com.mohamedrejeb.richeditor.ui.material3.OutlinedRichTextEditor
+
+private val PresetOrderedStyles: List<Pair<String, OrderedListStyleType>> = listOf(
+    "Decimal (1, 2, ...)" to OrderedListStyleType.Decimal,
+    "Lower alpha (a, b, ...)" to OrderedListStyleType.LowerAlpha,
+    "Upper alpha (A, B, ...)" to OrderedListStyleType.UpperAlpha,
+    "Lower roman (i, ii, ...)" to OrderedListStyleType.LowerRoman,
+    "Upper roman (I, II, ...)" to OrderedListStyleType.UpperRoman,
+    "Multiple (default)" to OrderedListStyleType.Multiple(
+        OrderedListStyleType.Decimal,
+        OrderedListStyleType.LowerRoman,
+        OrderedListStyleType.LowerAlpha,
+    ),
+)
+
+private val PresetUnorderedStyles: List<Pair<String, UnorderedListStyleType>> = listOf(
+    "Default (• ◦ ▪)" to UnorderedListStyleType.from("•", "◦", "▪"),
+    "Dashes (− ∙ ·)" to UnorderedListStyleType.from("−", "∙", "·"),
+    "Arrows (▸ ▹ ›)" to UnorderedListStyleType.from("▸", "▹", "›"),
+    "Stars (★ ☆ ✦)" to UnorderedListStyleType.from("★", "☆", "✦"),
+)
+
+private const val SampleHtml: String = """
+<p>Try the toggles above — watch how the pre-filled lists react.</p>
+<ol>
+    <li>First item</li>
+    <li>Second item</li>
+    <li>Third item</li>
+    <li>Fourth item</li>
+    <li>Fifth item</li>
+    <li>Sixth item</li>
+    <li>Seventh item</li>
+    <li>Eighth item</li>
+    <li>Ninth item</li>
+    <li>Tenth item — watch the jump from single to double digits</li>
+    <li>Eleventh item</li>
+    <li>Twelfth item</li>
+</ol>
+<ul>
+    <li>Top-level bullet
+        <ul>
+            <li>Second-level bullet
+                <ul>
+                    <li>Third-level bullet</li>
+                    <li>Another third-level bullet</li>
+                </ul>
+            </li>
+            <li>Another second-level bullet</li>
+        </ul>
+    </li>
+    <li>Another top-level bullet</li>
+</ul>
+"""
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalRichTextApi::class)
+@Composable
+fun ListsConfigSampleScreen(navigateBack: () -> Unit) {
+    val state = rememberRichTextState()
+
+    LaunchedEffect(Unit) {
+        state.setHtml(SampleHtml)
+    }
+
+    var orderedIndent by remember { mutableStateOf(state.config.orderedListIndent.toFloat()) }
+    var unorderedIndent by remember { mutableStateOf(state.config.unorderedListIndent.toFloat()) }
+    var alignment by remember { mutableStateOf(state.config.listPrefixAlignment) }
+    var orderedStyleIndex by remember { mutableStateOf(PresetOrderedStyles.lastIndex) }
+    var unorderedStyleIndex by remember { mutableStateOf(0) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Lists configuration") },
+                navigationIcon = {
+                    IconButton(onClick = navigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        modifier = Modifier.fillMaxSize(),
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .windowInsetsPadding(WindowInsets.ime)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Adjust the controls to see how each config affects ordered and unordered lists.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            SectionLabel("Prefix alignment")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ListPrefixAlignment.entries.forEach { option ->
+                    FilterChip(
+                        selected = alignment == option,
+                        onClick = {
+                            alignment = option
+                            state.config.listPrefixAlignment = option
+                        },
+                        label = { Text(option.name) },
+                    )
+                }
+            }
+            Text(
+                text = "End (default) aligns the dots of 1. and 10. vertically. Start gives every item a " +
+                        "uniform left edge. Try indent = 0 to see the safety fallback.",
+                style = MaterialTheme.typography.bodySmall,
+            )
+
+            SectionLabel("Ordered list indent — ${orderedIndent.toInt()} sp")
+            Slider(
+                value = orderedIndent,
+                valueRange = 0f..80f,
+                steps = 79,
+                onValueChange = {
+                    orderedIndent = it
+                    state.config.orderedListIndent = it.toInt()
+                },
+            )
+
+            SectionLabel("Unordered list indent — ${unorderedIndent.toInt()} sp")
+            Slider(
+                value = unorderedIndent,
+                valueRange = 0f..80f,
+                steps = 79,
+                onValueChange = {
+                    unorderedIndent = it
+                    state.config.unorderedListIndent = it.toInt()
+                },
+            )
+
+            SectionLabel("Ordered list style type")
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                PresetOrderedStyles.forEachIndexed { index, (label, styleType) ->
+                    FilterChip(
+                        selected = orderedStyleIndex == index,
+                        onClick = {
+                            orderedStyleIndex = index
+                            state.config.orderedListStyleType = styleType
+                        },
+                        label = { Text(label) },
+                    )
+                }
+            }
+
+            SectionLabel("Unordered list style type")
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                PresetUnorderedStyles.forEachIndexed { index, (label, styleType) ->
+                    FilterChip(
+                        selected = unorderedStyleIndex == index,
+                        onClick = {
+                            unorderedStyleIndex = index
+                            state.config.unorderedListStyleType = styleType
+                        },
+                        label = { Text(label) },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(4.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(4.dp))
+
+            OutlinedRichTextEditor(
+                state = state,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(420.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+    )
+}

--- a/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/navigation/NavGraph.kt
+++ b/sample/common/src/commonMain/kotlin/com/mohamedrejeb/richeditor/sample/common/navigation/NavGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.mohamedrejeb.richeditor.sample.common.home.HomeScreen
 import com.mohamedrejeb.richeditor.sample.common.htmleditor.HtmlEditorContent
+import com.mohamedrejeb.richeditor.sample.common.listsconfig.ListsConfigSampleScreen
 import com.mohamedrejeb.richeditor.sample.common.markdowneditor.MarkdownEditorContent
 import com.mohamedrejeb.richeditor.sample.common.mentions.MentionsSampleScreen
 import com.mohamedrejeb.richeditor.sample.common.richeditor.RichEditorScreen
@@ -19,6 +20,7 @@ private const val MARKDOWN_EDITOR_ROUTE = "markdownEditor"
 private const val SLACK_ROUTE = "slack"
 private const val MENTIONS_ROUTE = "mentions"
 private const val UNDO_REDO_ROUTE = "undoRedo"
+private const val LISTS_CONFIG_ROUTE = "listsConfig"
 
 @Composable
 fun NavGraph() {
@@ -36,6 +38,7 @@ fun NavGraph() {
                 navigateToSlack = { navController.navigate(SLACK_ROUTE) },
                 navigateToMentions = { navController.navigate(MENTIONS_ROUTE) },
                 navigateToUndoRedo = { navController.navigate(UNDO_REDO_ROUTE) },
+                navigateToListsConfig = { navController.navigate(LISTS_CONFIG_ROUTE) },
             )
         }
 
@@ -71,6 +74,12 @@ fun NavGraph() {
 
         composable(UNDO_REDO_ROUTE) {
             UndoRedoSampleScreen(
+                navigateBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(LISTS_CONFIG_ROUTE) {
+            ListsConfigSampleScreen(
                 navigateBack = { navController.popBackStack() }
             )
         }


### PR DESCRIPTION
- Introduced `ListPrefixAlignment` enum with `Start` and `End` options.
- Updated `RichTextConfig` to support `listPrefixAlignment` configuration.
- Enhanced ordered and unordered list layout logic for configurable prefix alignment.
- Added tests to verify alignment behavior for both list types and dynamic configuration changes.
- Updated documentation with examples and usage details.

Closes: #569 