### PR TITLE
fix: keep raw text and list prefixes in sync on config change

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -500,7 +500,13 @@ public class RichTextState internal constructor(
 
     public val config: RichTextConfig = RichTextConfig(
         updateText = {
-            updateTextFieldValue(textFieldValue)
+            // Config changes can alter paragraph prefix widths (e.g. switching
+            // orderedListStyleType from Decimal to LowerRoman changes "10. " to
+            // "x. "). Rebuild from the RichParagraph tree so the raw text and
+            // the rendered prefixes stay in sync; `updateAnnotatedString` relies
+            // on substring(...) against the current raw text and would read out
+            // of bounds when the prefix width has shifted.
+            updateRichParagraphList()
         }
     )
 

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/OrderedListStyleTypeSwitchTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/OrderedListStyleTypeSwitchTest.kt
@@ -1,0 +1,46 @@
+package com.mohamedrejeb.richeditor.model
+
+import com.mohamedrejeb.richeditor.paragraph.type.OrderedListStyleType
+import kotlin.test.Test
+
+/**
+ * Regression for a crash when switching [RichTextConfig.orderedListStyleType] at
+ * runtime while the editor already contains an ordered list whose prefix widths
+ * change between the two styles (e.g. "10. " → "viii. "). The raw text still
+ * held the old prefixes and `updateAnnotatedString` read children's text via
+ * substring using the *new* prefix length, causing a StringIndexOutOfBounds.
+ */
+class OrderedListStyleTypeSwitchTest {
+
+    private val sampleHtml = buildString {
+        append("<ol>")
+        (1..12).forEach { i -> append("<li>Item number $i</li>") }
+        append("</ol>")
+    }
+
+    @Test
+    fun switchingToLowerRomanDoesNotCrash() {
+        val state = RichTextState()
+        state.setHtml(sampleHtml)
+
+        state.config.orderedListStyleType = OrderedListStyleType.LowerRoman
+    }
+
+    @Test
+    fun switchingToUpperRomanDoesNotCrash() {
+        val state = RichTextState()
+        state.setHtml(sampleHtml)
+
+        state.config.orderedListStyleType = OrderedListStyleType.UpperRoman
+    }
+
+    @Test
+    fun switchingBackAndForthDoesNotCrash() {
+        val state = RichTextState()
+        state.setHtml(sampleHtml)
+
+        state.config.orderedListStyleType = OrderedListStyleType.LowerRoman
+        state.config.orderedListStyleType = OrderedListStyleType.UpperAlpha
+        state.config.orderedListStyleType = OrderedListStyleType.Decimal
+    }
+}


### PR DESCRIPTION
Switching orderedListStyleType at runtime (e.g. Decimal → LowerRoman) rewrites each paragraph's startRichSpan text from "10. " to "x. ", but the raw TextFieldValue still holds the old prefixes. The config's updateText hook then called updateTextFieldValue(textFieldValue), which routes to updateAnnotatedString and slices each child's content out of that stale raw text using the new prefix offsets. Across a 12-item ordered list the cumulative drift overruns the buffer and throws StringIndexOutOfBoundsException in AnnotatedStringExt.append.

Point config.updateText at updateRichParagraphList() instead. That path rebuilds the annotated string directly from the RichParagraph tree (no substring against raw text) and reassigns textFieldValue from the freshly built annotated string, so prefixes and raw text stay in lockstep regardless of prefix width changes.

Adds OrderedListStyleTypeSwitchTest covering the crash scenarios (switch to LowerRoman, UpperRoman, and back-and-forth through several styles) using a 12-item list that exercises both single- and double-digit markers.