### PR TITLE
fix: clamp End alignment firstLine to 0 instead of falling back to Start

### DIFF
--- a/docs/ordered_unordered_lists.md
+++ b/docs/ordered_unordered_lists.md
@@ -131,8 +131,10 @@ richTextState.config.listPrefixAlignment = ListPrefixAlignment.Start
 | `Start` | marker left-aligned to the indent origin, marker left edges stack | ``1.`` / ``10. `` / ``11. `` — numbers stacked |
 
 If the configured indent is smaller than the marker width (for example
-`orderedListIndent = 0`), `End` automatically falls back to `Start` for that
-paragraph so the marker stays visible.
+`orderedListIndent = 0`), `End` clamps the first-line indent at `0` so the
+marker stays visible. Clamping (rather than switching formulas per item) keeps
+the whole list on a single layout so paragraphs with different marker widths
+stay visually consistent.
 
 ## List Marker Style
 

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
@@ -113,13 +113,13 @@ internal class OrderedList private constructor(
         val base = (indent * level).toFloat()
         val prefix = startTextWidth.value
         // End: HTML-style alignment — prefix lives in the indent "gutter" and dots align
-        // vertically, but fall back to Start when the indent is too small so the prefix
-        // doesn't get clipped off the left edge.
+        // vertically. Clamp firstLine at 0 so the prefix stays visible when the indent is
+        // smaller than the prefix width; clamping per-item keeps all paragraphs on the
+        // same formula so items with different marker widths stay visually consistent.
         // Start: every item's prefix starts at the indent origin, giving a uniform left edge.
-        val useEnd = prefixAlignment == ListPrefixAlignment.End && base >= prefix
         val textIndent =
-            if (useEnd)
-                TextIndent(firstLine = (base - prefix).sp, restLine = base.sp)
+            if (prefixAlignment == ListPrefixAlignment.End)
+                TextIndent(firstLine = (base - prefix).coerceAtLeast(0f).sp, restLine = base.sp)
             else
                 TextIndent(firstLine = base.sp, restLine = (base + prefix).sp)
 

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/UnorderedList.kt
@@ -91,13 +91,13 @@ internal class UnorderedList private constructor(
     private fun getNewParagraphStyle(): ParagraphStyle {
         val base = (indent * level).toFloat()
         val prefix = startTextWidth.value
-        // End: HTML-style alignment — prefix lives in the indent "gutter"; fall back to
-        // Start when the indent is too small so the prefix doesn't get clipped.
+        // End: HTML-style alignment — prefix lives in the indent "gutter". Clamp firstLine
+        // at 0 so the prefix stays visible when the indent is smaller than the prefix;
+        // clamping (instead of switching formulas) keeps the layout consistent across items.
         // Start: every item's prefix starts at the indent origin.
-        val useEnd = prefixAlignment == ListPrefixAlignment.End && base >= prefix
         val textIndent =
-            if (useEnd)
-                TextIndent(firstLine = (base - prefix).sp, restLine = base.sp)
+            if (prefixAlignment == ListPrefixAlignment.End)
+                TextIndent(firstLine = (base - prefix).coerceAtLeast(0f).sp, restLine = base.sp)
             else
                 TextIndent(firstLine = base.sp, restLine = (base + prefix).sp)
 

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedListIndentTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedListIndentTest.kt
@@ -36,17 +36,19 @@ class OrderedListIndentTest {
     }
 
     @Test
-    fun indentSmallerThanPrefixKeepsPrefixVisible() {
+    fun indentSmallerThanPrefixClampsFirstLineToZero() {
         val config = config(indent = 10)
         val list = OrderedList(number = 1, config = config, startTextWidth = 50.sp)
 
         val textIndent = list.getStyle(config).textIndent
         assertNotNull(textIndent)
 
-        // 10 < 50: prefix would not fit in the gutter, so it moves inside.
-        assertEquals(10f, textIndent.firstLine.value)
-        assertEquals(60f, textIndent.restLine.value)
-        assertTrue(textIndent.firstLine.value >= 0f) // no clipping
+        // base (10) < prefix (50): the natural base - prefix would be -40, which would
+        // clip the marker. Clamp firstLine at 0 instead of flipping formulas — keeps
+        // every item in the list on the same layout regardless of per-item marker width.
+        assertEquals(0f, textIndent.firstLine.value)
+        assertEquals(10f, textIndent.restLine.value)
+        assertTrue(textIndent.firstLine.value >= 0f)
     }
 
     @Test
@@ -57,25 +59,47 @@ class OrderedListIndentTest {
         val textIndent = list.getStyle(config).textIndent
         assertNotNull(textIndent)
 
-        // Edge case: indent = 0 (from the original bug report).
+        // Edge case: indent = 0. firstLine clamps to 0; restLine stays at the base.
         assertEquals(0f, textIndent.firstLine.value)
-        assertEquals(20f, textIndent.restLine.value)
+        assertEquals(0f, textIndent.restLine.value)
     }
 
     @Test
     fun deeperLevelGrowsTheGutterAndRestoresDotAlignment() {
         val config = config(indent = 10)
-        // Level 2 multiplies base (10*2 = 20), which is still < prefix (50) → fallback.
+        // Level 2: base (20) < prefix (50) → firstLine clamps to 0.
         val listLevel2 = OrderedList(number = 1, config = config, startTextWidth = 50.sp, initialLevel = 2)
         val level2Indent = listLevel2.getStyle(config).textIndent!!
-        assertEquals(20f, level2Indent.firstLine.value)
-        assertEquals(70f, level2Indent.restLine.value)
+        assertEquals(0f, level2Indent.firstLine.value)
+        assertEquals(20f, level2Indent.restLine.value)
 
-        // At level 6, base (60) >= prefix (50) → we flip back to the dot-aligned layout.
+        // At level 6, base (60) >= prefix (50) → the dot-aligned layout is restored naturally.
         val listLevel6 = OrderedList(number = 1, config = config, startTextWidth = 50.sp, initialLevel = 6)
         val level6Indent = listLevel6.getStyle(config).textIndent!!
         assertEquals(10f, level6Indent.firstLine.value)
         assertEquals(60f, level6Indent.restLine.value)
+    }
+
+    @Test
+    fun endAlignmentAppliesConsistentFormulaRegardlessOfMarkerWidth() {
+        // Two items in the "same list" (same indent config) with different marker widths
+        // (e.g. "1." vs "viii."). Both must use the End formula so they render
+        // consistently; the old fallback would switch one to Start and make the list
+        // visually uneven.
+        val config = config(indent = 30)
+        val narrowMarker = OrderedList(number = 1, config = config, startTextWidth = 10.sp)
+        val wideMarker = OrderedList(number = 8, config = config, startTextWidth = 40.sp)
+
+        val narrowIndent = narrowMarker.getStyle(config).textIndent!!
+        val wideIndent = wideMarker.getStyle(config).textIndent!!
+
+        // Both items use the End formula with restLine = base.
+        assertEquals(30f, narrowIndent.restLine.value)
+        assertEquals(30f, wideIndent.restLine.value)
+
+        // Narrow marker fits in the gutter; wide marker clamps firstLine to 0.
+        assertEquals(20f, narrowIndent.firstLine.value)
+        assertEquals(0f, wideIndent.firstLine.value)
     }
 
     @Test


### PR DESCRIPTION
The per-item fallback made items in a single list pick different TextIndent formulas based on their marker width, so a list with both "1." and "viii." would visually shift between layouts. Clamp firstLine to >= 0 under End alignment and keep restLine at the base: every item shares the same formula and narrow markers still get the classic hanging indent.