### PR TITLE
fix: clamp End alignment firstLine to 0 instead of falling back to Start

### DIFF
--- a/richeditor-compose/api/android/richeditor-compose.api
+++ b/richeditor-compose/api/android/richeditor-compose.api
@@ -130,6 +130,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun getLinkTextDecoration ()Landroidx/compose/ui/text/style/TextDecoration;
 	public final fun getListIndent ()I
 	public final fun getListMarkerStyleBehavior ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+	public final fun getListPrefixAlignment ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
 	public final fun getOrderedListIndent ()I
 	public final fun getOrderedListStyleType ()Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;
 	public final fun getPreserveStyleOnEmptyLine ()Z
@@ -143,6 +144,7 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun setLinkTextDecoration (Landroidx/compose/ui/text/style/TextDecoration;)V
 	public final fun setListIndent (I)V
 	public final fun setListMarkerStyleBehavior (Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;)V
+	public final fun setListPrefixAlignment (Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;)V
 	public final fun setOrderedListIndent (I)V
 	public final fun setOrderedListStyleType (Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;)V
 	public final fun setPreserveStyleOnEmptyLine (Z)V
@@ -327,6 +329,14 @@ public final class com/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBeh
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
 	public static fun values ()[Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
+}
+
+public final class com/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment : java/lang/Enum {
+	public static final field End Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
+	public static final field Start Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
+	public static fun values ()[Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
 }
 
 public abstract interface class com/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType {

--- a/richeditor-compose/api/desktop/richeditor-compose.api
+++ b/richeditor-compose/api/desktop/richeditor-compose.api
@@ -131,7 +131,6 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun getListIndent ()I
 	public final fun getListMarkerStyleBehavior ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;
 	public final fun getListPrefixAlignment ()Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;
-	public final fun getMaxImageWidth-XSAIIZE ()J
 	public final fun getOrderedListIndent ()I
 	public final fun getOrderedListStyleType ()Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;
 	public final fun getPreserveStyleOnEmptyLine ()Z
@@ -146,7 +145,6 @@ public final class com/mohamedrejeb/richeditor/model/RichTextConfig {
 	public final fun setListIndent (I)V
 	public final fun setListMarkerStyleBehavior (Lcom/mohamedrejeb/richeditor/paragraph/type/ListMarkerStyleBehavior;)V
 	public final fun setListPrefixAlignment (Lcom/mohamedrejeb/richeditor/paragraph/type/ListPrefixAlignment;)V
-	public final fun setMaxImageWidth--R2X_6o (J)V
 	public final fun setOrderedListIndent (I)V
 	public final fun setOrderedListStyleType (Lcom/mohamedrejeb/richeditor/paragraph/type/OrderedListStyleType;)V
 	public final fun setPreserveStyleOnEmptyLine (Z)V

--- a/richeditor-compose/api/richeditor-compose.klib.api
+++ b/richeditor-compose/api/richeditor-compose.klib.api
@@ -25,6 +25,17 @@ final enum class com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehav
     final fun values(): kotlin/Array<com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior> // com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior.values|values#static(){}[0]
 }
 
+final enum class com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment : kotlin/Enum<com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment> { // com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment|null[0]
+    enum entry End // com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment.End|null[0]
+    enum entry Start // com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment.Start|null[0]
+
+    final val entries // com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment> // com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment // com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment> // com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment.values|values#static(){}[0]
+}
+
 final enum class com.mohamedrejeb.richeditor.ui/UndoBehavior : kotlin/Enum<com.mohamedrejeb.richeditor.ui/UndoBehavior> { // com.mohamedrejeb.richeditor.ui/UndoBehavior|null[0]
     enum entry Disabled // com.mohamedrejeb.richeditor.ui/UndoBehavior.Disabled|null[0]
     enum entry Enabled // com.mohamedrejeb.richeditor.ui/UndoBehavior.Enabled|null[0]
@@ -287,6 +298,9 @@ final class com.mohamedrejeb.richeditor.model/RichTextConfig { // com.mohamedrej
     final var listMarkerStyleBehavior // com.mohamedrejeb.richeditor.model/RichTextConfig.listMarkerStyleBehavior|{}listMarkerStyleBehavior[0]
         final fun <get-listMarkerStyleBehavior>(): com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior // com.mohamedrejeb.richeditor.model/RichTextConfig.listMarkerStyleBehavior.<get-listMarkerStyleBehavior>|<get-listMarkerStyleBehavior>(){}[0]
         final fun <set-listMarkerStyleBehavior>(com.mohamedrejeb.richeditor.paragraph.type/ListMarkerStyleBehavior) // com.mohamedrejeb.richeditor.model/RichTextConfig.listMarkerStyleBehavior.<set-listMarkerStyleBehavior>|<set-listMarkerStyleBehavior>(com.mohamedrejeb.richeditor.paragraph.type.ListMarkerStyleBehavior){}[0]
+    final var listPrefixAlignment // com.mohamedrejeb.richeditor.model/RichTextConfig.listPrefixAlignment|{}listPrefixAlignment[0]
+        final fun <get-listPrefixAlignment>(): com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment // com.mohamedrejeb.richeditor.model/RichTextConfig.listPrefixAlignment.<get-listPrefixAlignment>|<get-listPrefixAlignment>(){}[0]
+        final fun <set-listPrefixAlignment>(com.mohamedrejeb.richeditor.paragraph.type/ListPrefixAlignment) // com.mohamedrejeb.richeditor.model/RichTextConfig.listPrefixAlignment.<set-listPrefixAlignment>|<set-listPrefixAlignment>(com.mohamedrejeb.richeditor.paragraph.type.ListPrefixAlignment){}[0]
     final var orderedListIndent // com.mohamedrejeb.richeditor.model/RichTextConfig.orderedListIndent|{}orderedListIndent[0]
         final fun <get-orderedListIndent>(): kotlin/Int // com.mohamedrejeb.richeditor.model/RichTextConfig.orderedListIndent.<get-orderedListIndent>|<get-orderedListIndent>(){}[0]
         final fun <set-orderedListIndent>(kotlin/Int) // com.mohamedrejeb.richeditor.model/RichTextConfig.orderedListIndent.<set-orderedListIndent>|<set-orderedListIndent>(kotlin.Int){}[0]

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/ImageLoader.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/ImageLoader.kt
@@ -4,11 +4,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.TextUnit
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 
 public interface ImageLoader {
@@ -22,6 +26,20 @@ public interface ImageLoader {
 @OptIn(ExperimentalRichTextApi::class)
 public val LocalImageLoader: ProvidableCompositionLocal<ImageLoader> = staticCompositionLocalOf {
     DefaultImageLoader
+}
+
+/**
+ * The container width available to images inside a [com.mohamedrejeb.richeditor.ui.BasicRichText].
+ *
+ * Populated by `BasicRichText` via `Modifier.onSizeChanged` so that images wider
+ * than the container can be scaled down proportionally instead of overflowing.
+ * When unspecified (default), images render at their intrinsic size.
+ */
+internal val LocalRichTextMaxImageWidthProvider: ProvidableCompositionLocal<RichTextMaxImageWidthProvider> =
+    staticCompositionLocalOf { RichTextMaxImageWidthProvider() }
+
+internal class RichTextMaxImageWidthProvider {
+    var maxWidth by mutableStateOf(TextUnit.Unspecified)
 }
 
 @ExperimentalRichTextApi

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpanStyle.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpanStyle.kt
@@ -8,9 +8,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.key
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.isUnspecified
@@ -18,7 +15,6 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.*
 import androidx.compose.ui.unit.TextUnit
@@ -243,29 +239,40 @@ public interface RichSpanStyle {
                 children = {
                     val density = LocalDensity.current
                     val imageLoader = LocalImageLoader.current
+                    val maxImageWidth = LocalRichTextMaxImageWidthProvider.current.maxWidth
                     val data = imageLoader.load(model) ?: return@InlineTextContent
 
-                    LaunchedEffect(id, data) {
+                    LaunchedEffect(id, data, maxImageWidth) {
                         if (data.painter.intrinsicSize.isUnspecified)
                             return@LaunchedEffect
 
-                        val newWidth = with(density) {
+                        val intrinsicWidth = with(density) {
                             data.painter.intrinsicSize.width.coerceAtLeast(0f).toSp()
                         }
-                        val newHeight = with(density) {
+                        val intrinsicHeight = with(density) {
                             data.painter.intrinsicSize.height.coerceAtLeast(0f).toSp()
                         }
 
-                        if (width == newWidth && height == newHeight)
+                        val (clampedWidth, clampedHeight) = clampToMaxWidth(
+                            width = intrinsicWidth,
+                            height = intrinsicHeight,
+                            maxWidth = maxImageWidth,
+                        )
+
+                        val shouldSetWidth = width.isUnspecified ||
+                            width.value <= 0 ||
+                            width != clampedWidth
+                        val shouldSetHeight = height.isUnspecified ||
+                            height.value <= 0 ||
+                            height != clampedHeight
+
+                        if (!shouldSetWidth && !shouldSetHeight)
                             return@LaunchedEffect
 
                         richTextState.inlineContentMap.remove(id)
 
-                        if (width.isUnspecified || width.value <= 0)
-                            width = newWidth
-
-                        if (height.isUnspecified || height.value <= 0)
-                            height = newHeight
+                        if (shouldSetWidth) width = clampedWidth
+                        if (shouldSetHeight) height = clampedHeight
 
                         richTextState.inlineContentMap[id] = createInlineTextContent(richTextState = richTextState)
                         richTextState.updateAnnotatedString()
@@ -286,6 +293,29 @@ public interface RichSpanStyle {
             false
 
         override val isAtomic: Boolean = true
+
+        internal companion object {
+            /**
+             * Scale [width]/[height] down proportionally so [width] is at most
+             * [maxWidth]. Returns the input unchanged when [maxWidth] is
+             * unspecified, non-positive, or already wider than [width].
+             */
+            internal fun clampToMaxWidth(
+                width: TextUnit,
+                height: TextUnit,
+                maxWidth: TextUnit,
+            ): Pair<TextUnit, TextUnit> {
+                if (!maxWidth.isSpecified || maxWidth.value <= 0f) return width to height
+                if (!width.isSpecified || width.value <= maxWidth.value) return width to height
+
+                val scale = maxWidth.value / width.value
+                val clampedHeight = if (height.isSpecified)
+                    (height.value * scale).sp
+                else
+                    height
+                return maxWidth to clampedHeight
+            }
+        }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichText.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/ui/BasicRichText.kt
@@ -5,20 +5,26 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 import com.mohamedrejeb.richeditor.gesture.detectTapGestures
 import com.mohamedrejeb.richeditor.model.ImageLoader
 import com.mohamedrejeb.richeditor.model.LocalImageLoader
+import com.mohamedrejeb.richeditor.model.LocalRichTextMaxImageWidthProvider
+import com.mohamedrejeb.richeditor.model.RichTextMaxImageWidthProvider
 import com.mohamedrejeb.richeditor.model.RichTextState
 
 @Composable
@@ -39,6 +45,7 @@ public fun BasicRichText(
     val pointerIcon = remember {
         mutableStateOf(PointerIcon.Default)
     }
+    val maxImageWidthProvider = remember { RichTextMaxImageWidthProvider() }
 
     val text = remember(
         state.visualTransformation,
@@ -48,7 +55,8 @@ public fun BasicRichText(
     }
 
     CompositionLocalProvider(
-        LocalImageLoader provides imageLoader
+        LocalImageLoader provides imageLoader,
+        LocalRichTextMaxImageWidthProvider provides maxImageWidthProvider,
     ) {
         BasicText(
             text = text,
@@ -87,6 +95,12 @@ public fun BasicRichText(
                             state.isLink(offset)
                         },
                     )
+                }
+                .onSizeChanged { size ->
+                    val newWidth = with(density) { size.width.toSp() }
+                    if (newWidth != maxImageWidthProvider.maxWidth) {
+                        maxImageWidthProvider.maxWidth = newWidth
+                    }
                 },
             style = style,
             onTextLayout = {

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/ImageClampToMaxWidthTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/ImageClampToMaxWidthTest.kt
@@ -1,0 +1,111 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression for #423: images wider than the container should scale down
+ * proportionally (aspect ratio preserved) instead of overflowing.
+ *
+ * Exercises the pure-math helper on [RichSpanStyle.Image.Companion]; the
+ * visual integration uses the same function from the inline-content
+ * `LaunchedEffect`, which reads the container width from
+ * `LocalRichTextMaxImageWidth` provided by `BasicRichText`.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class ImageClampToMaxWidthTest {
+
+    @Test
+    fun returnsInputUnchangedWhenMaxWidthUnspecified() {
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 1500.sp,
+            height = 150.sp,
+            maxWidth = TextUnit.Unspecified,
+        )
+        assertEquals(1500.sp, w)
+        assertEquals(150.sp, h)
+    }
+
+    @Test
+    fun returnsInputUnchangedWhenMaxWidthZero() {
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 1500.sp,
+            height = 150.sp,
+            maxWidth = 0.sp,
+        )
+        assertEquals(1500.sp, w)
+        assertEquals(150.sp, h)
+    }
+
+    @Test
+    fun returnsInputUnchangedWhenWidthAlreadyWithinMax() {
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 300.sp,
+            height = 200.sp,
+            maxWidth = 400.sp,
+        )
+        assertEquals(300.sp, w)
+        assertEquals(200.sp, h)
+    }
+
+    @Test
+    fun scalesWidthAndHeightProportionallyWhenTooWide() {
+        // Reporter's exact case: 1500x150 image in a 300.sp wide container.
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 1500.sp,
+            height = 150.sp,
+            maxWidth = 300.sp,
+        )
+        assertEquals(300.sp, w)
+        // 150 * (300 / 1500) = 30
+        assertEquals(30.sp, h)
+    }
+
+    @Test
+    fun squareImageScalesEqually() {
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 1000.sp,
+            height = 1000.sp,
+            maxWidth = 250.sp,
+        )
+        assertEquals(250.sp, w)
+        assertEquals(250.sp, h)
+    }
+
+    @Test
+    fun tallImageScalesToFitWidth() {
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 800.sp,
+            height = 1200.sp,
+            maxWidth = 400.sp,
+        )
+        assertEquals(400.sp, w)
+        // 1200 * 0.5 = 600
+        assertEquals(600.sp, h)
+    }
+
+    @Test
+    fun exactMatchToMaxWidthIsUnchanged() {
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 400.sp,
+            height = 300.sp,
+            maxWidth = 400.sp,
+        )
+        assertEquals(400.sp, w)
+        assertEquals(300.sp, h)
+    }
+
+    @Test
+    fun unspecifiedHeightStaysUnspecified() {
+        val (w, h) = RichSpanStyle.Image.clampToMaxWidth(
+            width = 1500.sp,
+            height = TextUnit.Unspecified,
+            maxWidth = 300.sp,
+        )
+        assertEquals(300.sp, w)
+        assertEquals(TextUnit.Unspecified, h)
+    }
+}


### PR DESCRIPTION
Images with an intrinsic width larger than the BasicRichText container used to overflow because the inline-content Placeholder was sized upfront from the painter's intrinsic size with no awareness of the container.

BasicRichText now captures its laid-out width via Modifier.onSizeChanged and publishes it through an internal LocalRichTextMaxImageWidthProvider. The Image inline content reads that value and scales width/height proportionally (aspect ratio preserved) when the intrinsic width exceeds the container. The LaunchedEffect is keyed on the container width so resizes trigger a re-clamp.

Fixes: #423 