### PR TITLE
fix: emit blank line before list block in markdown decode (#441)

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
@@ -430,11 +430,27 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
             if (index < richTextState.richParagraphList.lastIndex) {
                 // Append new line
                 builder.appendLine()
+
+                // CommonMark requires a list block to be preceded by a blank line when it
+                // follows a non-list paragraph; otherwise a lone `-` underneath a non-empty
+                // line is parsed as a setext H2 underline (turning the paragraph into a
+                // heading and dropping the list). See #441.
+                val nextParagraph = richTextState.richParagraphList[index + 1]
+                if (
+                    !isBlank &&
+                    !richParagraph.type.isList() &&
+                    nextParagraph.type.isList()
+                ) {
+                    builder.appendLine()
+                }
             }
         }
 
         return correctMarkdownText(builder.toString())
     }
+
+    private fun ParagraphType.isList(): Boolean =
+        this is OrderedList || this is UnorderedList
 
     @OptIn(ExperimentalRichTextApi::class)
     private fun decodeRichSpanToMarkdown(

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/Issue441ListBlankLineTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/Issue441ListBlankLineTest.kt
@@ -1,0 +1,123 @@
+package com.mohamedrejeb.richeditor.parser.markdown
+
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichSpan
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.paragraph.RichParagraph
+import com.mohamedrejeb.richeditor.paragraph.type.DefaultParagraph
+import com.mohamedrejeb.richeditor.paragraph.type.OrderedList
+import com.mohamedrejeb.richeditor.paragraph.type.UnorderedList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Reproduces https://github.com/MohamedRejeb/compose-rich-editor/issues/441
+ *
+ * When a paragraph of plain text is followed by a list, the markdown emitted
+ * by [RichTextState.toMarkdown] glues the list directly under the text:
+ *
+ *     Text
+ *     -
+ *     - item
+ *
+ * CommonMark interprets "Text\n-" as a setext H2 (the `-` underline rule),
+ * turning the paragraph into a heading and dropping the list. The fix is to
+ * insert a blank line between the text paragraph and the list.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class Issue441ListBlankLineTest {
+
+    @Test
+    fun textFollowedByEmptyBulletThenItem_producesBlankSeparator() {
+        val state = RichTextState(
+            initialRichParagraphList = listOf(
+                RichParagraph(type = DefaultParagraph()).also { paragraph ->
+                    paragraph.children.add(
+                        RichSpan(text = "Text", paragraph = paragraph)
+                    )
+                },
+                RichParagraph(type = UnorderedList()),
+                RichParagraph(type = UnorderedList()).also { paragraph ->
+                    paragraph.children.add(
+                        RichSpan(text = "item", paragraph = paragraph)
+                    )
+                },
+            )
+        )
+
+        val markdown = state.toMarkdown()
+
+        // CommonMark setext-heading test: any `-` directly under non-empty text
+        // converts it into a heading. The fix should insert a blank line.
+        val lines = markdown.split('\n')
+        val textIndex = lines.indexOfFirst { it.trimEnd() == "Text" }
+        assertTrue(textIndex >= 0, "Text line not found in:\n$markdown")
+        val nextLine = lines.getOrNull(textIndex + 1)
+        assertEquals(
+            "",
+            nextLine?.trimEnd(),
+            "Expected blank line after `Text` before list, got `$nextLine`. Full markdown:\n$markdown"
+        )
+    }
+
+    @Test
+    fun textFollowedByListItem_producesBlankSeparator() {
+        val state = RichTextState(
+            initialRichParagraphList = listOf(
+                RichParagraph(type = DefaultParagraph()).also { paragraph ->
+                    paragraph.children.add(
+                        RichSpan(text = "Text", paragraph = paragraph)
+                    )
+                },
+                RichParagraph(type = UnorderedList()).also { paragraph ->
+                    paragraph.children.add(
+                        RichSpan(text = "item", paragraph = paragraph)
+                    )
+                },
+            )
+        )
+
+        val markdown = state.toMarkdown()
+
+        val lines = markdown.split('\n')
+        val textIndex = lines.indexOfFirst { it.trimEnd() == "Text" }
+        assertTrue(textIndex >= 0, "Text line not found in:\n$markdown")
+        val nextLine = lines.getOrNull(textIndex + 1)
+        assertEquals(
+            "",
+            nextLine?.trimEnd(),
+            "Expected blank line after `Text` before list, got `$nextLine`. Full markdown:\n$markdown"
+        )
+    }
+
+    @Test
+    fun textFollowedByOrderedList_producesBlankSeparator() {
+        val state = RichTextState(
+            initialRichParagraphList = listOf(
+                RichParagraph(type = DefaultParagraph()).also { paragraph ->
+                    paragraph.children.add(
+                        RichSpan(text = "Text", paragraph = paragraph)
+                    )
+                },
+                RichParagraph(type = OrderedList(number = 1)).also { paragraph ->
+                    paragraph.children.add(
+                        RichSpan(text = "item", paragraph = paragraph)
+                    )
+                },
+            )
+        )
+
+        val markdown = state.toMarkdown()
+
+        val lines = markdown.split('\n')
+        val textIndex = lines.indexOfFirst { it.trimEnd() == "Text" }
+        assertTrue(textIndex >= 0, "Text line not found in:\n$markdown")
+        val nextLine = lines.getOrNull(textIndex + 1)
+        assertEquals(
+            "",
+            nextLine?.trimEnd(),
+            "Expected blank line after `Text` before list, got `$nextLine`. Full markdown:\n$markdown"
+        )
+    }
+}


### PR DESCRIPTION
When a non-list paragraph was followed by a list, the decoder wrote only a single newline between them. CommonMark interprets a lone `-` directly beneath a non-empty line as a setext H2 underline, so output like `Text\n-\n- item` collapsed `Text` into a heading and dropped the list entirely.

Insert an extra newline at the non-list -> list transition so the list block starts on its own paragraph. Skip the extra newline when the current paragraph is itself blank (the existing blank-paragraph machinery already produces the separator) or already a list (lists chain without a blank-line break).

Fixes: #441 