### PR TITLE
fix: cache list prefix widths to avoid first-frame indent flicker

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
 import com.mohamedrejeb.richeditor.annotation.InternalRichTextApi
 import androidx.compose.ui.util.fastCoerceAtLeast
 import androidx.compose.ui.util.fastFirstOrNull
@@ -114,6 +116,16 @@ public class RichTextState internal constructor(
 
     internal val inlineContentMap = mutableStateMapOf<String, InlineTextContent>()
     internal val usedInlineContentMapKeys = mutableSetOf<String>()
+
+    /**
+     * Measured pixel widths (in `sp`) of list-prefix strings ("• ", "1. ", "10. ", etc.),
+     * captured by [adjustRichParagraphLayout] after each text layout. Used to pre-populate
+     * `startTextWidth` on freshly-created [ConfigurableStartTextWidth] paragraph types
+     * before the first paint, so toggle-list, setMarkdown, setHtml, and paste paths render
+     * the correct `TextIndent` on the very first frame instead of relying on the
+     * onTextLayout self-correction (which causes a one-frame "indent jump" flicker).
+     */
+    internal val startTextWidthCache: MutableMap<String, TextUnit> = mutableMapOf()
 
     /**
      * Pending HTML from clipboard, set by platform clipboard managers during [getClipEntry].
@@ -2286,6 +2298,12 @@ public class RichTextState internal constructor(
 
         usedInlineContentMapKeys.clear()
 
+        // Pre-fill `startTextWidth` on any freshly-added list paragraphs so the first
+        // frame uses the correct `TextIndent`. Without this, every toggle / setMarkdown
+        // / paste path renders one frame at `firstLine = base` before the layout pass
+        // measures the prefix and corrects it.
+        applyCachedStartTextWidths()
+
         annotatedString = buildAnnotatedString {
             var index = 0
             richParagraphList.fastForEachIndexed { i, richParagraph ->
@@ -4101,12 +4119,44 @@ public class RichTextState internal constructor(
                         paragraphType.startTextWidth = distanceSp
                         isParagraphUpdated = true
                     }
+                    // Remember the measured width for this prefix string so future
+                    // paragraphs with the same prefix can render correctly on the first
+                    // frame instead of relying on this self-correction pass.
+                    startTextWidthCache[paragraphType.startText] = distanceSp
                 }
             }
         }
 
         if (isParagraphUpdated)
             updateTextFieldValue(textFieldValue)
+    }
+
+    /**
+     * Pre-populates `startTextWidth` on any list-style paragraphs that were just
+     * created with `0.sp` (the default) using widths previously measured for the
+     * same prefix string. Called immediately before each render path rebuilds the
+     * annotated string so the first paint of a fresh list paragraph picks up the
+     * correct `TextIndent` instead of one frame at the indent origin.
+     */
+    private fun applyCachedStartTextWidths() {
+        if (startTextWidthCache.isEmpty()) return
+        richParagraphList.fastForEach { paragraph ->
+            val type = paragraph.type
+            if (type is ConfigurableStartTextWidth && type.startTextWidth == 0.sp) {
+                startTextWidthCache[type.startText]?.let { cached ->
+                    type.startTextWidth = cached
+                }
+            }
+        }
+    }
+
+    /**
+     * Test-only: simulates an `adjustRichParagraphLayout` pass having recorded a
+     * measured prefix width for [startText]. Used to verify the cache → render
+     * pipeline without spinning up a real Compose layout in unit tests.
+     */
+    internal fun recordMeasuredPrefixWidthForTest(startText: String, width: TextUnit) {
+        startTextWidthCache[startText] = width
     }
 
     internal fun getLinkByOffset(offset: Offset): String? {
@@ -4752,6 +4802,11 @@ public class RichTextState internal constructor(
         val newStyledRichSpanList = mutableListOf<RichSpan>()
 
         usedInlineContentMapKeys.clear()
+
+        // See [updateAnnotatedString] for why this runs before the rebuild — same
+        // reason: ensures freshly-parsed list paragraphs from setMarkdown / setHtml
+        // get the cached prefix width before their first frame.
+        applyCachedStartTextWidths()
 
         annotatedString = buildAnnotatedString {
             var index = 0

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateListPrefixWidthCacheTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateListPrefixWidthCacheTest.kt
@@ -1,0 +1,117 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.unit.sp
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.paragraph.type.ConfigurableStartTextWidth
+import com.mohamedrejeb.richeditor.paragraph.type.OrderedList
+import com.mohamedrejeb.richeditor.paragraph.type.ParagraphType.Companion.startText
+import com.mohamedrejeb.richeditor.paragraph.type.UnorderedList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the list-prefix flicker.
+ *
+ * Newly-created [UnorderedList] / [OrderedList] paragraph types start with
+ * `startTextWidth = 0.sp`. Without a cache, every render path that creates
+ * fresh paragraph types (setMarkdown / setHtml / toggle list / paste) renders
+ * one frame with the wrong `TextIndent` before `onTextLayout` measures the
+ * prefix and corrects it. The cache stores measured widths keyed by the
+ * prefix string so the next paragraph with the same prefix renders correctly
+ * on the first frame.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextStateListPrefixWidthCacheTest {
+
+    @Test
+    fun setMarkdown_appliesCachedPrefixWidthToNewParagraphs() {
+        val state = RichTextState()
+
+        state.setMarkdown("- one")
+        val firstPara = state.richParagraphList[0].type
+        require(firstPara is ConfigurableStartTextWidth)
+
+        // Simulate the result of `adjustRichParagraphLayout` having measured
+        // the bullet width on first render.
+        firstPara.startTextWidth = 12.sp
+        state.startTextWidthCache[firstPara.startText] = 12.sp
+
+        // Streaming-style replacement — same prefix, more items.
+        state.setMarkdown("- one\n- two\n- three")
+
+        state.richParagraphList.forEachIndexed { index, paragraph ->
+            val type = paragraph.type
+            assertTrue(type is ConfigurableStartTextWidth, "Paragraph $index should be a list")
+            assertEquals(
+                expected = 12.sp,
+                actual = type.startTextWidth,
+                message = "Paragraph $index should have inherited the cached prefix width",
+            )
+        }
+    }
+
+    @Test
+    fun toggleList_appliesCachedPrefixWidthToNewParagraph() {
+        val state = RichTextState()
+        state.setText("first")
+
+        // First toggle — measure as if onTextLayout had run.
+        state.toggleUnorderedList()
+        val firstList = state.richParagraphList[0].type
+        require(firstList is ConfigurableStartTextWidth)
+        firstList.startTextWidth = 12.sp
+        state.startTextWidthCache[firstList.startText] = 12.sp
+
+        // Toggle off, type a second paragraph, toggle on again.
+        state.toggleUnorderedList()
+        state.addTextAfterSelection("\nsecond")
+        state.toggleUnorderedList()
+
+        val secondList = state.richParagraphList.last().type
+        require(secondList is ConfigurableStartTextWidth)
+        assertEquals(
+            expected = 12.sp,
+            actual = secondList.startTextWidth,
+            message = "Toggling another list with the same prefix should pre-fill from cache",
+        )
+    }
+
+    @Test
+    fun setMarkdown_skipsCacheForChangedPrefix() {
+        val state = RichTextState()
+
+        state.setMarkdown("1. one")
+        val firstOl = state.richParagraphList[0].type
+        require(firstOl is OrderedList)
+        firstOl.startTextWidth = 14.sp
+        state.startTextWidthCache[firstOl.startText] = 14.sp
+
+        // Switch to an unordered list — different prefix string, cache miss expected.
+        state.setMarkdown("- one")
+        val unordered = state.richParagraphList[0].type
+        require(unordered is UnorderedList)
+        assertEquals(
+            expected = 0f,
+            actual = unordered.startTextWidth.value,
+            message = "Different prefix string should not pull from a stale ordered-list cache entry",
+        )
+    }
+
+    @Test
+    fun adjustLayout_writesPrefixWidthToCache() {
+        val state = RichTextState()
+
+        // Manually pretend the adjust pass ran and stored a width.
+        state.recordMeasuredPrefixWidthForTest("• ", 11.sp)
+
+        // Cache value should be queryable.
+        assertEquals(11.sp, state.startTextWidthCache["• "])
+
+        // Subsequent setMarkdown picks it up automatically.
+        state.setMarkdown("- one")
+        val type = state.richParagraphList[0].type
+        require(type is ConfigurableStartTextWidth)
+        assertEquals(11.sp, type.startTextWidth)
+    }
+}


### PR DESCRIPTION
Freshly-created UnorderedList/OrderedList paragraphs start with startTextWidth = 0.sp, so the first render uses TextIndent(firstLine = base, restLine = base) and only gets corrected after onTextLayout measures the prefix. Every setMarkdown, setHtml, paste, and toggleList path creates new instances, so the flicker happened on every list creation and on every chunk during markdown streaming.

Cache measured prefix widths on RichTextState keyed by the prefix string ("• ", "1. ", "10. ", etc.) and pre-fill startTextWidth from the cache before each render path rebuilds the annotated string. After the first encounter of a given prefix, subsequent list creations render with the correct TextIndent on the first frame.