### PR TITLE
fix: guard checkForParagraphs against out-of-bounds sliceIndex (StringIndexOutOfBoundsException)

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -3055,6 +3055,14 @@ public class RichTextState internal constructor(
             // This is to make sure that the index is not in paragraph custom start text
             val sliceIndex = max(index, richSpan.textRange.min)
 
+            // Guard: a prior loop iteration may have inserted startText into tempTextFieldValue,
+            // leaving span textRanges stale (they will be reconciled by updateAnnotatedString).
+            // If sliceIndex points past the current text end, skip rather than crash on substring.
+            if (sliceIndex >= tempTextFieldValue.text.length) {
+                index--
+                continue
+            }
+
             // Create a new paragraph style
             val newParagraph = richSpan.paragraph.slice(
                 startIndex = sliceIndex,


### PR DESCRIPTION
## Problem

`checkForParagraphs` crashes with `StringIndexOutOfBoundsException` when processing text that contains multiple newlines to split into paragraphs in a single call.

```
Fatal Exception: java.lang.StringIndexOutOfBoundsException: begin 0, end 476, length 475
  at java.lang.String.substring(String.java:2948)
  at RichTextState.checkForParagraphs(RichTextState.kt:3107)
  at RichTextState.updateTextFieldValue(RichTextState.kt:2085)
  at RichTextState.onTextFieldValueChange(RichTextState.kt:1994)
```

## Root cause

The `checkForParagraphs` loop processes newlines one at a time. Each iteration that creates a list paragraph inserts the `startText` prefix (e.g. `"1. "`) into `tempTextFieldValue.text`, making the text grow. Span `textRange` values are **not** updated until the subsequent `updateAnnotatedString` call.

On the **next loop iteration**, when the fallback path is taken (line 3036–3038):

```kotlin
if (richSpan == null && index == tempTextFieldValue.text.lastIndex && breakThreshold == 0) {
    richSpan = richParagraphList.lastOrNull()?.getLastNonEmptyChild()
}
```

the returned span's `textRange.min` still reflects the **old** (pre-insertion) text layout. Combined with:

```kotlin
val sliceIndex = max(index, richSpan.textRange.min)
```

`sliceIndex` can equal `text.length` (one past the last valid index). The subsequent:

```kotlin
val beforeText = tempTextFieldValue.text.substring(0, sliceIndex + 1)  // ← crash
```

throws `StringIndexOutOfBoundsException: begin 0, end N+1, length N`.

## Fix

Apply the same `index--; continue` skip pattern already used for the `null`-span and missing-paragraph-index cases: if `sliceIndex` is out of bounds, skip this iteration. The `updateAnnotatedString` call (which runs immediately after `checkForParagraphs` returns) will reconcile all span `textRange` values before the next edit event.

```kotlin
if (sliceIndex >= tempTextFieldValue.text.length) {
    index--
    continue
}
```

## Affected versions

Reproducible on `1.0.0-rc14`. The fallback at line 3036 was introduced in #658, which opened the window for stale `textRange.min` to exceed `text.length` under certain IME input sequences.

## Testing

Verified the fix compiles cleanly. The crash is intermittent and triggered by specific IME multi-paragraph input sequences; it is difficult to reproduce deterministically in a unit test without mocking the IME layer.