### PR TITLE
fix(ios): strip source background-color from clipboard HTML on paste

### DIFF
--- a/richeditor-compose/src/iosMain/kotlin/com/mohamedrejeb/richeditor/clipboard/IosRichTextClipboardManager.kt
+++ b/richeditor-compose/src/iosMain/kotlin/com/mohamedrejeb/richeditor/clipboard/IosRichTextClipboardManager.kt
@@ -44,7 +44,7 @@ internal class IosRichTextClipboardManager(
                 val html = NSString.create(data = htmlData, encoding = NSUTF8StringEncoding)
                     ?.toString()
                 if (html != null) {
-                    richTextState.pendingClipboardHtml = html
+                    richTextState.pendingClipboardHtml = stripSourceBackgroundColor(html)
                 }
             }
         } catch (e: Exception) {
@@ -96,4 +96,26 @@ internal class IosRichTextClipboardManager(
         const val HTML_UTI = "public.html"
         const val PLAIN_TEXT_UTI = "public.utf8-plain-text"
     }
+
+    /**
+     * iOS clipboard HTML carries the source document's background-color (typically white
+     * or transparent) on every span. Strip those so they don't render as white boxes
+     * behind the text inside the editor.
+     *
+     * Only white, near-white, and transparent values are removed. Intentional highlight
+     * colors (yellow, blue, etc.) are left intact.
+     */
+    private fun stripSourceBackgroundColor(html: String): String =
+        html.replace(
+            Regex(
+                """background-color\s*:\s*""" +
+                """(?:white|transparent""" +
+                """|#[fF]{3,6}""" +
+                """|rgb\(\s*255\s*,\s*255\s*,\s*255\s*\)""" +
+                """|rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*(?:0|1|1\.0|0\.0)\s*\)""" +
+                """)\s*;?""",
+                RegexOption.IGNORE_CASE,
+            ),
+            "",
+        )
 }


### PR DESCRIPTION
## Problem

When copying text from Safari, Notes, Mail, or any iOS app, the clipboard HTML includes the source document's `background-color` (typically `white` or `transparent`) on every span element. When pasted into the editor, these colors render as white/opaque boxes behind the text — making pasted content unreadable, especially in dark-themed apps.

**Repro steps:**
1. Open Safari on iOS and select any text on a webpage
2. Copy
3. Paste into a `RichTextEditor`
4. Pasted text appears with a white background box around it

This affects every iOS user who pastes content from a browser or native app.

## Fix

Strip `background-color` values that are white, near-white, or transparent from the clipboard HTML before it is stored in `pendingClipboardHtml`. The stripping happens in `IosRichTextClipboardManager.getClipEntry()`, before any parsing.

Removed values:
- `white`
- `transparent`
- `#fff`, `#ffff`, `#ffffff`, `#FFFFFF` (case-insensitive)
- `rgb(255, 255, 255)`
- `rgba(255, 255, 255, 0)` / `rgba(255, 255, 255, 1)`

**Intentional highlight colors (yellow, blue, green, etc.) are not affected** — the regex only targets the specific white/transparent family.

## Notes

- iOS-only change (`iosMain`) — Android and Desktop clipboard paths are unaffected
- No behavioral change for content with real highlight colors
- The fix is a pre-parse string replacement, so it adds negligible overhead