### PR TITLE
fix: replace OffsetMapping.Identity with clamping variant to prevent …

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -2360,10 +2360,11 @@ public class RichTextState internal constructor(
                 newTextFieldValue.selection.end.coerceIn(0, newTextLength),
             ),
         )
+        val safeAnnotatedString = annotatedString
         visualTransformation = VisualTransformation { _ ->
             TransformedText(
-                text = annotatedString,
-                offsetMapping = OffsetMapping.Identity
+                text = safeAnnotatedString,
+                offsetMapping = clampingOffsetMapping(safeAnnotatedString.text.length)
             )
         }
         styledRichSpanList.addAll(newStyledRichSpanList)
@@ -4858,10 +4859,11 @@ public class RichTextState internal constructor(
             text = annotatedString.text,
             selection = TextRange(selectionIndex),
         )
+        val safeAnnotatedString = annotatedString
         visualTransformation = VisualTransformation { _ ->
             TransformedText(
-                text = annotatedString,
-                offsetMapping = OffsetMapping.Identity
+                text = safeAnnotatedString,
+                offsetMapping = clampingOffsetMapping(safeAnnotatedString.text.length)
             )
         }
         styledRichSpanList.addAll(newStyledRichSpanList)
@@ -5145,3 +5147,20 @@ public class RichTextState internal constructor(
         )
     }
 }
+
+/**
+ * Creates an [OffsetMapping] that behaves like [OffsetMapping.Identity] but
+ * clamps offsets to valid ranges instead of crashing. This guards against
+ * a race condition where [RichTextState.textFieldValue] and
+ * [RichTextState.visualTransformation] are read from different snapshot
+ * versions during recomposition (e.g. in a LazyColumn scroll), causing
+ * the original and transformed text lengths to temporarily differ.
+ */
+private fun clampingOffsetMapping(transformedLength: Int): OffsetMapping = object : OffsetMapping {
+    override fun originalToTransformed(offset: Int): Int =
+        offset.coerceIn(0, transformedLength)
+
+    override fun transformedToOriginal(offset: Int): Int =
+        offset.coerceIn(0, transformedLength)
+}
+


### PR DESCRIPTION
…crash

The richeditor library stores textFieldValue and visualTransformation as separate mutableStateOf objects. When a LazyColumn recomposes the editor during scroll, Compose can read them from different snapshot versions, causing OffsetMapping.Identity to crash with IllegalStateException because annotatedString.length != textFieldValue.text.length. Replace OffsetMapping.Identity with a clampingOffsetMapping that coerces offsets to valid ranges instead of crashing. Behavior is identical when both texts have the same length (the normal case); in the transient desync case the UI may show a slightly off scroll position for one frame instead of crashing the app.