### PR TITLE
Fix ordered list numbering when parsing Markdown

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
@@ -153,6 +153,22 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
                             (currentRichParagraphType as ConfigurableListLevel).level = currentListLevel
                         }
 
+                        // Preserve the author's actual ordered-list number via startFrom so it
+                        // survives renumbering even when a non-list paragraph splits the list.
+                        val orderedNumber = node
+                            .findChildOfType(MarkdownTokenTypes.LIST_NUMBER)
+                            ?.getTextInNode(correctedMarkdown)
+                            ?.toString()?.trim()
+                            ?.let { it.substring(0, it.length - 1).trimStart('0').toIntOrNull() }
+
+                        if (orderedNumber != null && currentRichParagraphType is OrderedList) {
+                            currentRichParagraphType = OrderedList(
+                                number = orderedNumber,
+                                initialLevel = currentListLevel,
+                                startFrom = orderedNumber,
+                            )
+                        }
+
                         currentRichParagraph.type = currentRichParagraphType
                     }
 

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownOrderedListStartTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownOrderedListStartTest.kt
@@ -1,0 +1,43 @@
+package com.mohamedrejeb.richeditor.parser.markdown
+
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.paragraph.type.OrderedList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression tests for ordered-list numbering parsed from Markdown.
+ *
+ * The author's numbers must be preserved instead of being reset to 1, both
+ * when the list starts at a number other than 1 (e.g. `5. `) and when a
+ * non-list paragraph is interleaved between items.
+ */
+class RichTextStateMarkdownOrderedListStartTest {
+
+    private fun orderedListNumbers(markdown: String): List<Int> {
+        val state = RichTextState()
+        state.setMarkdown(markdown)
+        return state.richParagraphList.mapNotNull { (it.type as? OrderedList)?.number }
+    }
+
+    @Test
+    fun listStartingAtOneIsSequential() {
+        assertEquals(listOf(1, 2, 3), orderedListNumbers("1. a\n2. b\n3. c"))
+    }
+
+    @Test
+    fun listStartingAtFivePreservesStartNumber() {
+        assertEquals(listOf(5, 6), orderedListNumbers("5. five\n6. six"))
+    }
+
+    @Test
+    fun listStartingAtMultiDigitPreservesStartNumber() {
+        assertEquals(listOf(10, 11, 12), orderedListNumbers("10. ten\n11. eleven\n12. twelve"))
+    }
+
+    @Test
+    fun numberingSurvivesParagraphBetweenItems() {
+        val markdown = "1. first\n   continuation\n\n2. second\n3. third"
+        assertEquals(listOf(1, 2, 3), orderedListNumbers(markdown))
+    }
+}


### PR DESCRIPTION
## Problem

Ordered lists parsed from Markdown lose their numbering in two cases.

A list that starts at a number other than 1 always renders from 1

```
5. five
6. six
```

renders as `1.`, `2.` instead of `5.`, `6.`.

And when a paragraph appears between items, the numbering restarts

```
1. first
   continuation paragraph

2. second
3. third
```

renders as `1.`, `1.`, `2.` instead of `1.`, `2.`, `3.`.

## Cause

When the Markdown parser builds an ordered list it creates `OrderedList(0)` and ignores the number written in the source. The numbers are later recomputed in `RichTextState.checkParagraphsType`, which reads the first item's value from `startFrom`. The Markdown parser never sets `startFrom`, so it defaults to 1.

The HTML parser already sets `startFrom` from `<ol start="N">`, so the same content works when it comes in as HTML. The Markdown path just didn't have an equivalent.

The second case is the same gap seen from a different angle: a non-list paragraph between items clears the running counter in `checkParagraphsType`, so the following item falls back to `startFrom`, which was 1 for every item.

## Fix

Read each list item's own number from the Markdown AST (`LIST_NUMBER`) and carry it through `startFrom`. The recompute pass then keeps the author's numbering, and items that follow an interleaved paragraph resume from the right value instead of resetting to 1.

The change is contained to `RichTextStateMarkdownParser`.

## Tests

Added `RichTextStateMarkdownOrderedListStartTest` covering sequential lists, lists starting at a custom number, multi-digit starts, and numbering across an interleaved paragraph. `apiCheck` and the existing list and markdown tests pass.
