### PR TITLE
fix: diff-based edit pipeline, selection stability, parser round-trips

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -1929,12 +1929,6 @@ public class RichTextState internal constructor(
     private var tempTextFieldValue = textFieldValue
 
     /**
-     * Set to true when the IME revert is detected (#640), so [checkForParagraphs]
-     * uses a threshold of 0 to scan all newlines.
-     */
-    private var forceCheckAllNewlines = false
-
-    /**
      * Handles the new text field value.
      *
      * @param newTextFieldValue the new text field value.
@@ -1953,7 +1947,10 @@ public class RichTextState internal constructor(
             }
             newText.length < oldText.length ->
                 CommitTrigger.Delete(caret = newTextFieldValue.selection.min)
-            newText == oldText && newTextFieldValue.selection != textFieldValue.selection ->
+            // Same-length replacement (autocorrect rewrite): its own undo group.
+            newText != oldText ->
+                CommitTrigger.Structural
+            newTextFieldValue.selection != textFieldValue.selection ->
                 CommitTrigger.SelectionJump
             else -> null
         }
@@ -2001,66 +1998,129 @@ public class RichTextState internal constructor(
 
         tempTextFieldValue = newTextFieldValue
 
-        if (tempTextFieldValue.text.length > textFieldValue.text.length)
-            handleAddingCharacters()
-        else if (tempTextFieldValue.text.length < textFieldValue.text.length) {
-            val newNewlineCount = tempTextFieldValue.text.count { it == '\n' }
-            val oldNewlineCount = textFieldValue.text.count { it == '\n' }
-            val isImeRevert = newNewlineCount > oldNewlineCount
-                && !singleParagraphMode
-                && richParagraphList.size > 1
-                && textFieldValue.selection.collapsed
+        val oldTextFieldValue = textFieldValue
+        val oldText = oldTextFieldValue.text
+        val newText = tempTextFieldValue.text
 
-            // Selection replacement: old selection was a range and the new text fits the
-            // pattern of "selection removed + optional replacement chars at selection start".
-            // Split into two steps: remove the old selection, then add any replacement chars.
-            val selMin = textFieldValue.selection.min
-            val selMax = textFieldValue.selection.max
-            val pureRemovalText = textFieldValue.text.substring(0, selMin) +
-                textFieldValue.text.substring(selMax)
-            val newTextStartsWithPrefix = tempTextFieldValue.text.length >= selMin &&
-                tempTextFieldValue.text.substring(0, selMin) == textFieldValue.text.substring(0, selMin)
-            val replacementCount = tempTextFieldValue.text.length - pureRemovalText.length
-            val isSelectionReplacement = !textFieldValue.selection.collapsed &&
-                !isImeRevert &&
-                newTextStartsWithPrefix &&
-                replacementCount >= 0 &&
-                tempTextFieldValue.text.length >= selMin + replacementCount &&
-                tempTextFieldValue.text.substring(selMin + replacementCount) ==
-                    textFieldValue.text.substring(selMax)
+        if (newText != oldText) {
+            // Diff the real changed region (longest common prefix/suffix): IME batch
+            // edits can change text away from the selection, so the selection alone
+            // cannot be trusted (#716).
+            var commonPrefix = 0
+            val maxCommon = minOf(oldText.length, newText.length)
+            while (
+                commonPrefix < maxCommon &&
+                oldText[commonPrefix] == newText[commonPrefix]
+            ) commonPrefix++
+            var commonSuffix = 0
+            val maxSuffix = maxCommon - commonPrefix
+            while (
+                commonSuffix < maxSuffix &&
+                oldText[oldText.lastIndex - commonSuffix] == newText[newText.lastIndex - commonSuffix]
+            ) commonSuffix++
 
-            if (isImeRevert) {
-                // IME revert: merge last paragraph back, let checkForParagraphs rebuild. See #640.
-                val lastParagraph = richParagraphList.removeAt(richParagraphList.lastIndex)
-                val precedingParagraph = richParagraphList.last()
-                lastParagraph.updateChildrenParagraph(precedingParagraph)
-                precedingParagraph.children.addAll(lastParagraph.children)
-                forceCheckAllNewlines = true
-            } else if (isSelectionReplacement) {
-                // Step 1: remove the old selection as a pure deletion
-                val actualNewTextFieldValue = tempTextFieldValue
-                tempTextFieldValue = textFieldValue.copy(
-                    text = pureRemovalText,
-                    selection = TextRange(selMin),
-                )
-                handleRemovingCharacters()
+            val removedLength = oldText.length - commonPrefix - commonSuffix
+            val insertedLength = newText.length - commonPrefix - commonSuffix
 
-                // Step 2: if there are replacement chars, add them
-                if (replacementCount > 0) {
-                    updateTextFieldValue()
-                    tempTextFieldValue = actualNewTextFieldValue
-                    if (actualNewTextFieldValue.text.length > textFieldValue.text.length) {
-                        handleAddingCharacters()
+            when {
+                removedLength == 0 && insertedLength > 0 -> {
+                    // Pure insertion. The diff position is ambiguous inside runs of
+                    // repeated characters; prefer the selection-derived position when
+                    // it describes the same change.
+                    val legacyStart = oldTextFieldValue.selection.min
+                    val legacyDescribesChange =
+                        legacyStart in 0..oldText.length &&
+                            newText.substring(0, legacyStart) == oldText.substring(0, legacyStart) &&
+                            newText.substring(legacyStart + insertedLength) == oldText.substring(legacyStart)
+                    handleAddingCharacters(
+                        startTypeIndex = if (legacyDescribesChange) legacyStart else commonPrefix,
+                        typedCharsCount = insertedLength,
+                        positionFromSelection = legacyDescribesChange,
+                    )
+                }
+
+                insertedLength == 0 && removedLength > 0 -> {
+                    // Pure removal, same ambiguity rule using the new selection.
+                    val legacyMin = tempTextFieldValue.selection.min
+                    val legacyDescribesChange =
+                        legacyMin in 0..newText.length &&
+                            legacyMin + removedLength <= oldText.length &&
+                            oldText.substring(0, legacyMin) == newText.substring(0, legacyMin) &&
+                            oldText.substring(legacyMin + removedLength) == newText.substring(legacyMin)
+                    handleRemovingCharacters(
+                        minRemoveIndex = if (legacyDescribesChange) legacyMin else commonPrefix,
+                        removedCharsCount = removedLength,
+                    )
+                }
+
+                removedLength > 0 && insertedLength > 0 -> {
+                    // Replacement: removal followed by insertion. Prefer the old
+                    // selection bounds when they describe the change, else the diff bounds.
+                    val selMin = oldTextFieldValue.selection.min
+                    val selMax = oldTextFieldValue.selection.max
+                    val selReplacementLength = newText.length - selMin - (oldText.length - selMax)
+                    val selectionDescribesChange = !oldTextFieldValue.selection.collapsed &&
+                        selReplacementLength >= 0 &&
+                        selMin + selReplacementLength <= newText.length &&
+                        newText.substring(0, selMin) == oldText.substring(0, selMin) &&
+                        newText.substring(selMin + selReplacementLength) == oldText.substring(selMax)
+
+                    val removeStart: Int
+                    val removeEnd: Int
+                    if (selectionDescribesChange) {
+                        removeStart = selMin
+                        removeEnd = selMax
+                    } else {
+                        removeStart = commonPrefix
+                        removeEnd = oldText.length - commonSuffix
+                    }
+                    val replacement = newText.substring(
+                        removeStart,
+                        newText.length - (oldText.length - removeEnd),
+                    )
+
+                    // Step 1: apply the removal as a pure deletion
+                    val actualNewTextFieldValue = tempTextFieldValue
+                    tempTextFieldValue = oldTextFieldValue.copy(
+                        text = oldText.substring(0, removeStart) + oldText.substring(removeEnd),
+                        selection = TextRange(removeStart),
+                    )
+                    handleRemovingCharacters(
+                        minRemoveIndex = removeStart,
+                        removedCharsCount = removeEnd - removeStart,
+                    )
+
+                    // Step 2: insert the replacement on top of the CURRENT text; the
+                    // removal may have rewritten it (prefix removal, renumbering), so
+                    // the IME's view is stale.
+                    if (replacement.isNotEmpty()) {
+                        updateTextFieldValue()
+                        val insertPosition = textFieldValue.selection.min
+                            .coerceIn(0, textFieldValue.text.length)
+                        val stepTwoText = textFieldValue.text.substring(0, insertPosition) +
+                            replacement +
+                            textFieldValue.text.substring(insertPosition)
+                        // If the removal didn't rewrite surrounding text, the IME's
+                        // reported caret is still valid; keep it.
+                        tempTextFieldValue = actualNewTextFieldValue.copy(
+                            text = stepTwoText,
+                            selection = if (stepTwoText == actualNewTextFieldValue.text)
+                                actualNewTextFieldValue.selection
+                            else
+                                TextRange(insertPosition + replacement.length),
+                        )
+                        // positionFromSelection = false: the insert position is
+                        // reconstructed, so the Android-suggestion heuristic could
+                        // misread the preserved IME caret and inject a phantom space.
+                        handleAddingCharacters(
+                            startTypeIndex = insertPosition,
+                            typedCharsCount = replacement.length,
+                            positionFromSelection = false,
+                        )
                     }
                 }
-            } else {
-                handleRemovingCharacters()
             }
-        }
-        else if (
-            tempTextFieldValue.text == textFieldValue.text &&
-            tempTextFieldValue.selection != textFieldValue.selection
-        ) {
+        } else if (tempTextFieldValue.selection != textFieldValue.selection) {
             val lastPressPosition = this.lastPressPosition
             if (lastPressPosition != null) {
                 adjustSelection(lastPressPosition, newTextFieldValue.selection)
@@ -2085,6 +2145,22 @@ public class RichTextState internal constructor(
             checkForParagraphs()
         }
 
+        // The span tree is the source of truth for the text: re-derive it before the
+        // rebuild so the two can never desync (#716 crash family). Skipped on pure
+        // selection changes, the drag-selection hot path (#730).
+        if (tempTextFieldValue.text != textFieldValue.text) {
+            val treeText = computeTextFromTree()
+            if (treeText != tempTextFieldValue.text) {
+                tempTextFieldValue = tempTextFieldValue.copy(
+                    text = treeText,
+                    selection = TextRange(
+                        tempTextFieldValue.selection.start.coerceIn(0, treeText.length),
+                        tempTextFieldValue.selection.end.coerceIn(0, treeText.length),
+                    ),
+                )
+            }
+        }
+
         // Track the last non-collapsed selection for clipboard operations
         if (!textFieldValue.selection.collapsed) {
             lastNonCollapsedSelection = textFieldValue.selection
@@ -2101,8 +2177,12 @@ public class RichTextState internal constructor(
             // background from hiding the system selection highlight). If either the
             // previous or the new selection is non-collapsed, the mask set differs and
             // the cached annotatedString is stale - so force a rebuild. See #635.
+            // The mask only changes the output when a span has a background color;
+            // rebuilding otherwise recreates the visualTransformation mid-gesture and
+            // breaks selection on Android (#730, #731).
             val maskAffected =
-                !textFieldValue.selection.collapsed || !tempTextFieldValue.selection.collapsed
+                (!textFieldValue.selection.collapsed || !tempTextFieldValue.selection.collapsed) &&
+                    treeHasBackgroundSpans()
             if (maskAffected) {
                 updateAnnotatedString(tempTextFieldValue)
             } else {
@@ -2130,6 +2210,31 @@ public class RichTextState internal constructor(
 
         // Clear [tempTextFieldValue]
         tempTextFieldValue = TextFieldValue()
+    }
+
+    /**
+     * True when any span resolves to a [SpanStyle] with a specified background color,
+     * the only case the #635 selection mask changes the rendered output.
+     */
+    private fun treeHasBackgroundSpans(): Boolean {
+        fun spanHasBackground(richSpan: RichSpan): Boolean {
+            if (richSpan.spanStyle.background.isSpecified) return true
+
+            val richSpanStyle = richSpan.richSpanStyle
+            val resolvedStyle =
+                if (richSpanStyle is RichSpanStyle.Token)
+                    findTrigger(richSpanStyle.triggerId)?.style(config)
+                        ?: richSpanStyle.spanStyle(config)
+                else
+                    richSpanStyle.spanStyle(config)
+            if (resolvedStyle.background.isSpecified) return true
+
+            return richSpan.children.any { spanHasBackground(it) }
+        }
+
+        return richParagraphList.any { paragraph ->
+            paragraph.children.any { spanHasBackground(it) }
+        }
     }
 
     private inner class HistoryHostImpl : RichTextHistoryHost {
@@ -2360,9 +2465,12 @@ public class RichTextState internal constructor(
                 newTextFieldValue.selection.end.coerceIn(0, newTextLength),
             ),
         )
+        // Snapshot by value: the lambda runs during measure, where a live
+        // `annotatedString` read would race the textFieldValue captured at composition.
+        val transformed = annotatedString
         visualTransformation = VisualTransformation { _ ->
             TransformedText(
-                text = annotatedString,
+                text = transformed,
                 offsetMapping = OffsetMapping.Identity
             )
         }
@@ -2373,10 +2481,20 @@ public class RichTextState internal constructor(
      * Handles adding characters to the text field.
      * This method will update the [richParagraphList] to reflect the new changes.
      * This method will use the [tempTextFieldValue] to get the new characters.
+     *
+     * @param startTypeIndex the index in [tempTextFieldValue]'s text where the insertion begins.
+     * @param typedCharsCount the number of inserted characters.
+     * @param positionFromSelection true when [startTypeIndex] came from the selection;
+     * the Android-suggestion heuristic assumes a caret-derived position and must not
+     * fire for diff-derived positions.
      */
-    private fun handleAddingCharacters() {
-        val typedCharsCount = tempTextFieldValue.text.length - textFieldValue.text.length
-        var startTypeIndex = textFieldValue.selection.min
+    private fun handleAddingCharacters(
+        startTypeIndex: Int,
+        typedCharsCount: Int,
+        positionFromSelection: Boolean,
+    ) {
+        @Suppress("NAME_SHADOWING")
+        var startTypeIndex = startTypeIndex
         val typedText = tempTextFieldValue.text.substring(
             startIndex = startTypeIndex,
             endIndex = startTypeIndex + typedCharsCount,
@@ -2395,7 +2513,8 @@ public class RichTextState internal constructor(
 
         if (activeRichSpan != null) {
             val isAndroidSuggestion =
-                activeRichSpan.isLastInParagraph &&
+                positionFromSelection &&
+                        activeRichSpan.isLastInParagraph &&
                         activeRichSpan.textRange.max == startTypeIndex &&
                         tempTextFieldValue.selection.max == startTypeIndex + typedCharsCount + 1
 
@@ -2531,13 +2650,16 @@ public class RichTextState internal constructor(
      * Handles removing characters from the text field value.
      * This method will update the [richParagraphList] to reflect the new changes.
      * This method will use the [tempTextFieldValue] to get the removed characters.
+     *
+     * @param minRemoveIndex the index in the old text where the removed range begins.
+     * @param removedCharsCount the number of removed characters.
      */
-    private fun handleRemovingCharacters() {
-        val removedCharsCount = textFieldValue.text.length - tempTextFieldValue.text.length
-
-        val minRemoveIndex =
-            tempTextFieldValue.selection.min
-                .coerceAtLeast(0)
+    private fun handleRemovingCharacters(
+        minRemoveIndex: Int,
+        removedCharsCount: Int,
+    ) {
+        @Suppress("NAME_SHADOWING")
+        val minRemoveIndex = minRemoveIndex.coerceAtLeast(0)
 
         val maxRemoveIndex =
             (minRemoveIndex + removedCharsCount)
@@ -2617,10 +2739,18 @@ public class RichTextState internal constructor(
             }
         }
 
+        // Prefix handling must only run when the removal actually cuts into the max
+        // paragraph's prefix; a range ending at its start leaves it untouched.
+        val maxPrefixStart = maxParagraphFirstChildMinIndex - maxParagraphStartTextLength
+        val removalCutsMaxPrefix =
+            maxParagraphStartTextLength > 0 &&
+                maxRemoveIndex > maxPrefixStart &&
+                maxRemoveIndex < maxParagraphFirstChildMinIndex
+
         // Handle Remove the max paragraph custom text
         if (
             (minParagraphIndex == maxParagraphIndex || minRemoveIndex >= minParagraphFirstChildMinIndex) &&
-            maxRemoveIndex < maxParagraphFirstChildMinIndex
+            removalCutsMaxPrefix
         ) {
             handleRemoveMaxParagraphStartText(
                 minRemoveIndex = minRemoveIndex,
@@ -2637,8 +2767,7 @@ public class RichTextState internal constructor(
         } else if (
             minParagraphIndex != maxParagraphIndex &&
             minRemoveIndex < minParagraphFirstChildMinIndex &&
-            maxRemoveIndex < maxParagraphFirstChildMinIndex &&
-            maxParagraphStartTextLength > 0
+            removalCutsMaxPrefix
         ) {
             // Cross-paragraph removal: both min and max paragraph prefixes are partially cut.
             // Leftover max prefix chars remain in tempTextFieldValue.text; preserve them by
@@ -2678,12 +2807,20 @@ public class RichTextState internal constructor(
                         minParagraphFirstChildMinIndex
                     ) == null
 
-                if (isMaxParagraphEmpty) {
+                if (isMinParagraphEmpty && isMaxParagraphEmpty) {
+                    // Both paragraphs are empty: as many lines disappear as paragraph
+                    // separators the removal consumed, so the min paragraph survives
+                    // unless the separator before it is inside the range.
+                    val minParagraphPrefixStart =
+                        minParagraphFirstChildMinIndex - minParagraphStartTextLength
+                    richParagraphList.remove(maxRichSpan.paragraph)
+                    if (minRemoveIndex < minParagraphPrefixStart) {
+                        richParagraphList.remove(minRichSpan.paragraph)
+                    }
+                } else if (isMaxParagraphEmpty) {
                     // Remove the max paragraph if it's empty
                     richParagraphList.remove(maxRichSpan.paragraph)
-                }
-
-                if (isMinParagraphEmpty) {
+                } else if (isMinParagraphEmpty) {
                     // Set the min paragraph type to the max paragraph type
                     // Since the max paragraph is going to take the min paragraph's place
 //                    maxRichSpan.paragraph.type = minRichSpan.paragraph.type
@@ -2759,6 +2896,26 @@ public class RichTextState internal constructor(
             startParagraphIndex = minParagraphIndex - 1,
             endParagraphIndex = minParagraphIndex + 1,
         )
+    }
+
+    /**
+     * Serializes the current [richParagraphList] to the plain text exactly as
+     * [updateAnnotatedString] will emit it: each paragraph's list prefix followed by
+     * its span tree's text, with a single space separating paragraphs.
+     */
+    private fun computeTextFromTree(): String = buildString {
+        fun appendSpanText(richSpan: RichSpan) {
+            append(richSpan.text)
+            richSpan.children.fastForEach { appendSpanText(it) }
+        }
+
+        richParagraphList.fastForEachIndexed { index, paragraph ->
+            append(paragraph.type.startRichSpan.text)
+            paragraph.children.fastForEach { appendSpanText(it) }
+            if (!singleParagraphMode && index != richParagraphList.lastIndex) {
+                append(' ')
+            }
+        }
     }
 
     private fun handleRemoveMinParagraphStartText(
@@ -2941,30 +3098,48 @@ public class RichTextState internal constructor(
         startParagraphIndex: Int,
         endParagraphIndex: Int,
     ) {
-        // The map to store the list number of each list level, level -> number
+        // List number per level. Seed it by walking back through the list run so a
+        // window starting at a deep level still knows the shallower levels' numbers.
         val levelNumberMap = mutableMapOf<Int, Int>()
-        val startParagraph = richParagraphList.getOrNull(startParagraphIndex)
-        val startParagraphType = startParagraph?.type
-        if (startParagraphType is OrderedList)
-            levelNumberMap[startParagraphType.level] = startParagraphType.number
+        run {
+            val blockedLevels = mutableSetOf<Int>()
+            // Levels deeper than the shallowest item seen are completed runs; don't seed them.
+            var maxSeedableLevel = Int.MAX_VALUE
+            var seedIndex = startParagraphIndex
+            while (seedIndex >= 0) {
+                val seedType = richParagraphList.getOrNull(seedIndex)?.type ?: break
+                if (seedType !is ConfigurableListLevel) break
+                if (seedType.level <= maxSeedableLevel) {
+                    if (
+                        seedType is OrderedList &&
+                        seedType.level !in levelNumberMap &&
+                        seedType.level !in blockedLevels
+                    ) {
+                        levelNumberMap[seedType.level] = seedType.number
+                    }
+                    if (seedType is UnorderedList && seedType.level !in levelNumberMap) {
+                        blockedLevels.add(seedType.level)
+                    }
+                    maxSeedableLevel = seedType.level
+                }
+                seedIndex--
+            }
+        }
 
-        if (startParagraphIndex == -1)
-            levelNumberMap[1] = 0
-
-        // Update the paragraph type of the paragraphs after the new paragraph
-        for (i in (startParagraphIndex + 1)..richParagraphList.lastIndex) {
+        // Update the paragraph type of the paragraphs after the new paragraph;
+        // a negative start means "renumber from the beginning".
+        for (i in (startParagraphIndex + 1).coerceAtLeast(0)..richParagraphList.lastIndex) {
             val currentParagraph = richParagraphList[i]
             val currentParagraphType = currentParagraph.type
 
             if (currentParagraphType is ConfigurableListLevel) {
-                // Clear the completed list levels
-                levelNumberMap.filterKeys { level ->
+                // Clear the completed list levels: a shallower item ends all deeper runs.
+                levelNumberMap.keys.retainAll { level ->
                     level <= currentParagraphType.level
                 }
             } else {
                 // Clear the map if the current paragraph is not a list
                 levelNumberMap.clear()
-                levelNumberMap[1] = 0
             }
 
             // Remove current list level from map if the current paragraph is an unordered list
@@ -2972,10 +3147,12 @@ public class RichTextState internal constructor(
                 levelNumberMap.remove(currentParagraphType.level)
 
             if (currentParagraphType is OrderedList) {
+                // The first item of a run starts at its startFrom; following items count up.
+                val isFirstOfRun = currentParagraphType.level !in levelNumberMap
                 val number =
                     levelNumberMap[currentParagraphType.level]
                         ?.plus(1)
-                        ?: currentParagraphType.number
+                        ?: currentParagraphType.startFrom
 
                 levelNumberMap[currentParagraphType.level] = number
 
@@ -2985,7 +3162,8 @@ public class RichTextState internal constructor(
                         number = number,
                         config = config,
                         startTextWidth = currentParagraphType.startTextWidth,
-                        initialLevel = currentParagraphType.level
+                        initialLevel = currentParagraphType.level,
+                        startFrom = if (isFirstOfRun) currentParagraphType.startFrom else 1,
                     ),
                     textFieldValue = tempTextFieldValue,
                 )
@@ -3010,16 +3188,14 @@ public class RichTextState internal constructor(
         // paragraph prefix (e.g. "2. ") but keeps the newline, the newline
         // position ends up before the old selection, so the normal threshold
         // would skip it. See #640.
-        // Lower the threshold to scan all newlines when:
-        // - forceCheckAllNewlines: set by IME revert detection in onTextFieldValueChange
-        // - There's a single paragraph but the text has newlines: autocorrect shortened
-        //   text + added newline in one onValueChange call (the newline is before the
-        //   old cursor, so the normal threshold would skip it). See #640.
+        // Lower the threshold to scan all newlines when there's a single paragraph but
+        // the text has newlines: autocorrect shortened text + added newline in one
+        // onValueChange call (the newline is before the old cursor, so the normal
+        // threshold would skip it). See #640.
         val actualNewlines = tempTextFieldValue.text.count { it == '\n' }
         val breakThreshold =
-            if (forceCheckAllNewlines || (actualNewlines > 0 && richParagraphList.size == 1)) 0
+            if (actualNewlines > 0 && richParagraphList.size == 1) 0
             else textFieldValue.selection.min
-        forceCheckAllNewlines = false
 
         while (true) {
             // Search for the next paragraph
@@ -3775,6 +3951,7 @@ public class RichTextState internal constructor(
             richSpan.children.removeAt(i)
             childRichSpan.parent = newRichSpan
             childRichSpan.paragraph = newRichParagraph
+            childRichSpan.updateChildrenParagraph(newRichParagraph)
             newRichSpan.children.add(childRichSpan)
         }
 
@@ -3789,6 +3966,7 @@ public class RichTextState internal constructor(
                     childRichSpan.spanStyle = childRichSpan.fullSpanStyle
                     childRichSpan.parent = null
                     childRichSpan.paragraph = newRichParagraph
+                    childRichSpan.updateChildrenParagraph(newRichParagraph)
                     newRichParagraph.children.add(childRichSpan)
                 }
                 currentRichSpan.children.removeRange(index + 1, currentRichSpan.children.size)
@@ -3802,6 +3980,7 @@ public class RichTextState internal constructor(
                 childRichSpan.spanStyle = childRichSpan.fullSpanStyle
                 childRichSpan.parent = null
                 childRichSpan.paragraph = newRichParagraph
+                childRichSpan.updateChildrenParagraph(newRichParagraph)
                 newRichParagraph.children.add(childRichSpan)
             }
             richSpan.paragraph.children.removeRange(index + 1, richSpan.paragraph.children.size)
@@ -4242,7 +4421,14 @@ public class RichTextState internal constructor(
         val selection = newSelection ?: this.selection
         var pressX = pressPosition.x
         var pressY = pressPosition.y
-        val textLayoutResult = this.textLayoutResult ?: return
+        val textLayoutResult = this.textLayoutResult ?: run {
+            // No layout yet: the caret workaround can't run, but the platform's
+            // selection must still be applied (#730).
+            if (newSelection != null) {
+                applyAdjustedSelection(newSelection)
+            }
+            return
+        }
         var index = 0
         var lastIndex = 0
 
@@ -4301,7 +4487,12 @@ public class RichTextState internal constructor(
         if (index > richParagraphList.lastIndex)
             index = richParagraphList.lastIndex
 
-        val selectedParagraph = richParagraphList.getOrNull(index) ?: return
+        val selectedParagraph = richParagraphList.getOrNull(index) ?: run {
+            if (newSelection != null) {
+                applyAdjustedSelection(newSelection)
+            }
+            return
+        }
         val nextParagraph = richParagraphList.getOrNull(index + 1)
         val nextParagraphStart =
             if (nextParagraph == null)
@@ -4338,17 +4529,23 @@ public class RichTextState internal constructor(
                 )
             )
         } else if (newSelection != null) {
-            // Ensure newSelection is within valid bounds
-            val adjustedSelection = TextRange(
-                newSelection.start.coerceIn(0, textLength),
-                newSelection.end.coerceIn(0, textLength)
-            )
-            updateTextFieldValue(
-                textFieldValue.copy(
-                    selection = adjustedSelection
+            applyAdjustedSelection(newSelection)
+        }
+    }
+
+    /**
+     * Applies a platform selection clamped to the current text bounds.
+     */
+    private fun applyAdjustedSelection(newSelection: TextRange) {
+        val textLength = textFieldValue.text.length
+        updateTextFieldValue(
+            textFieldValue.copy(
+                selection = TextRange(
+                    newSelection.start.coerceIn(0, textLength),
+                    newSelection.end.coerceIn(0, textLength),
                 )
             )
-        }
+        )
     }
 
     private var registerLastPressPositionJob: Job? = null
@@ -4547,21 +4744,34 @@ public class RichTextState internal constructor(
     /**
      * Updates the [RichTextState] with the given [text].
      *
+     * Like [setHtml] and [setMarkdown], this is a programmatic replace: it clears the
+     * undo/redo history.
+     *
      * @param text The text to update the [RichTextState] with.
      */
     public fun setText(
         text: String,
         selection: TextRange = TextRange(text.length),
     ): RichTextState {
+        // A programmatic load is not a typing event: clear history (like setHtml /
+        // setMarkdown) and suppress recording for the load itself.
+        history.onProgrammaticReplace()
+
         val textFieldValue =
             TextFieldValue(
                 text = text,
                 selection = selection,
             )
 
-        onTextFieldValueChange(
-            newTextFieldValue = textFieldValue
-        )
+        val wasSuppressed = suppressHistoryRecording
+        suppressHistoryRecording = true
+        try {
+            onTextFieldValueChange(
+                newTextFieldValue = textFieldValue
+            )
+        } finally {
+            suppressHistoryRecording = wasSuppressed
+        }
         return this
     }
 
@@ -4858,9 +5068,11 @@ public class RichTextState internal constructor(
             text = annotatedString.text,
             selection = TextRange(selectionIndex),
         )
+        // Snapshot by value: see the matching note in `updateAnnotatedString`.
+        val transformed = annotatedString
         visualTransformation = VisualTransformation { _ ->
             TransformedText(
-                text = annotatedString,
+                text = transformed,
                 offsetMapping = OffsetMapping.Identity
             )
         }

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/paragraph/type/OrderedList.kt
@@ -161,6 +161,7 @@ internal class OrderedList private constructor(
             initialLevel = level,
             initialStyleType = styleType,
             initialPrefixAlignment = prefixAlignment,
+            startFrom = startFrom,
         )
 
     override fun equals(other: Any?): Boolean {

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParser.kt
@@ -32,6 +32,9 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
         val richParagraphList = mutableListOf(RichParagraph())
         val lineBreakParagraphIndexSet = mutableSetOf<Int>()
         val toKeepEmptyParagraphIndexSet = mutableSetOf<Int>()
+        // Blank-looking paragraphs that are real content (empty <li>, entity-encoded
+        // whitespace) and must survive recycling and the blank-paragraph cleanup.
+        val preservedBlankParagraphs = mutableSetOf<RichParagraph>()
         var currentRichSpan: RichSpan? = null
         var currentListLevel = 0
         // Tracks the next item number per list nesting level for ordered lists.
@@ -81,6 +84,12 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                     currentRichSpan = safeCurrentRichSpan
                     currentRichParagraph.children.add(safeCurrentRichSpan)
                 }
+
+                // Entity-encoded whitespace is real content even when the paragraph
+                // looks blank ("<p>&#32;</p>", "<p>&#x20;</p>").
+                if (SpaceEntityRegex.containsMatchIn(it)) {
+                    preservedBlankParagraphs.add(currentRichParagraph)
+                }
             }
             .onOpenTag { name, attributes, _ ->
                 val lastOpenedTag = openedTags.lastOrNull()?.first
@@ -92,6 +101,14 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                 }
 
                 if (name == "ul" || name == "ol") {
+                    // An empty <li> hosting a nested list is visible content; don't let
+                    // the first nested item recycle it.
+                    richParagraphList.lastOrNull()?.let { paragraph ->
+                        if (paragraph.isBlank() && paragraph.type is ConfigurableListLevel) {
+                            preservedBlankParagraphs.add(paragraph)
+                        }
+                    }
+
                     currentListLevel += 1
                     if (name == "ol") {
                         val startAttr = attributes["start"]?.toIntOrNull() ?: 1
@@ -116,7 +133,8 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                 val tagParagraphStyle = htmlElementsParagraphStyleEncodeMap[name]
 
                 val currentRichParagraph = richParagraphList.lastOrNull()
-                val isCurrentRichParagraphBlank = currentRichParagraph?.isBlank() == true
+                val isCurrentRichParagraphBlank = currentRichParagraph?.isBlank() == true &&
+                    currentRichParagraph !in preservedBlankParagraphs
                 val isCurrentTagBlockElement = name in htmlBlockElements
                 val isLastOpenedTagBlockElement = lastOpenedTag in htmlBlockElements
 
@@ -276,7 +294,19 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
             .onCloseTag { name, _ ->
                 openedTags.removeLastOrNull()
 
-                val isCurrentRichParagraphBlank = richParagraphList.lastOrNull()?.isBlank() == true
+                val lastRichParagraph = richParagraphList.lastOrNull()
+                val isCurrentRichParagraphBlank = lastRichParagraph?.isBlank() == true &&
+                    lastRichParagraph !in preservedBlankParagraphs
+
+                // An empty <li> is visible content (its marker renders); preserve it.
+                if (name == "li" && isCurrentRichParagraphBlank) {
+                    richParagraphList.lastOrNull()?.let { paragraph ->
+                        if (paragraph.type !is DefaultParagraph) {
+                            preservedBlankParagraphs.add(paragraph)
+                        }
+                    }
+                }
+
                 val isCurrentTagBlockElement = name in htmlBlockElements && name != "li"
 
                 if (isCurrentTagBlockElement && !isCurrentRichParagraphBlank) {
@@ -346,8 +376,13 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
         parser.end()
 
         for (i in richParagraphList.lastIndex downTo 0) {
-            // Keep empty paragraphs if they are line breaks <br> or by block html elements
-            if (i in lineBreakParagraphIndexSet || (i != richParagraphList.lastIndex && i in toKeepEmptyParagraphIndexSet))
+            // Keep empty paragraphs if they are line breaks <br>, kept block elements,
+            // or empty list items (whose marker is visible content)
+            if (
+                i in lineBreakParagraphIndexSet ||
+                (i != richParagraphList.lastIndex && i in toKeepEmptyParagraphIndexSet) ||
+                richParagraphList[i] in preservedBlankParagraphs
+            )
                 continue
 
             // Remove empty paragraphs
@@ -377,17 +412,37 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
 
         val builder = StringBuilder()
 
-        val openedListTagNames = mutableListOf<String>()
-        var lastParagraphGroupTagName: String? = null
-        var lastParagraphGroupLevel = 0
+        // Open list elements, outermost first. `hasHostItem` records that the list was
+        // opened inside a withheld parent <li>, so closing it also closes that item (#736).
+        class OpenList(val tag: String, val hasHostItem: Boolean)
+
+        val openLists = mutableListOf<OpenList>()
+
+        // Item/paragraph tag left open because the next paragraph is a <br> continuation.
+        var openItemTag: String? = null
+
+        // Level of the list item whose </li> is withheld so the next, deeper list can
+        // nest inside it. 0 when no item is withheld.
+        var hostItemLevel = 0
+
         var isLastParagraphEmpty = false
 
-        var currentListLevel = 0
+        val paragraphs = richTextState.richParagraphList
 
-        richTextState.richParagraphList.fastForEachIndexed { index, richParagraph ->
+        fun closeListsDownTo(level: Int) {
+            while (openLists.size > level) {
+                val closed = openLists.removeAt(openLists.lastIndex)
+                builder.append("</${closed.tag}>")
+                if (closed.hasHostItem)
+                    builder.append("</li>")
+            }
+        }
+
+        paragraphs.fastForEachIndexed { index, richParagraph ->
             val richParagraphType = richParagraph.type
             val isParagraphEmpty = richParagraph.isEmpty()
             val paragraphGroupTagName = decodeHtmlElementFromRichParagraph(richParagraph)
+            val isParagraphList = paragraphGroupTagName == "ol" || paragraphGroupTagName == "ul"
 
             val paragraphLevel =
                 if (richParagraphType is ConfigurableListLevel)
@@ -395,182 +450,180 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
                 else
                     0
 
-            val isParagraphList = paragraphGroupTagName in listOf("ol", "ul")
-            val isLastParagraphList = lastParagraphGroupTagName in listOf("ol", "ul")
+            // If this paragraph carries a heading, the <hN> tag is meant to imply the
+            // heading's typography. Strip the heading defaults from the paragraph CSS and the
+            // child span CSS via diff so user-added styles ride on top, but the heading
+            // visuals stay implied by the tag alone.
+            val headingStyle = richParagraph.headingStyle
 
-            fun isCloseParagraphGroup(): Boolean {
-                if (!isLastParagraphList)
-                    return false
+            val nextParagraph = paragraphs.getOrNull(index + 1)
+            val nextIsLineBreakContinuation = nextParagraph != null &&
+                nextParagraph.isFromLineBreak &&
+                !nextParagraph.isEmpty()
 
-                if (paragraphLevel > lastParagraphGroupLevel)
-                    return false
-
-                if (
-                    lastParagraphGroupTagName == paragraphGroupTagName &&
-                    paragraphLevel == lastParagraphGroupLevel
-                )
-                    return false
-
-                return true
-            }
-
-            fun isCloseAllOpenedTags(): Boolean {
-                if (isParagraphList)
-                    return false
-
-                if (!isLastParagraphList)
-                    return false
-
-                return true
-            }
-
-            fun isOpenParagraphGroup(): Boolean {
-                if (!isParagraphList)
-                    return false
-
-                if (
-                    isLastParagraphList &&
-                    paragraphGroupTagName == openedListTagNames.lastOrNull() &&
-                    paragraphLevel < lastParagraphGroupLevel
-                )
-                    return false
-
-                if (
-                    isLastParagraphList &&
-                    paragraphLevel == lastParagraphGroupLevel &&
-                    paragraphGroupTagName == lastParagraphGroupTagName
-                )
-                    return false
-
-                return true
-            }
-
-            if (isCloseAllOpenedTags()) {
-                openedListTagNames.fastForEachReversed {
-                    builder.append("</$it>")
+            // A <br> continuation rides inside the still-open owning tag and must
+            // bypass the list bookkeeping, or it would close the list mid-item.
+            if (richParagraph.isFromLineBreak && openItemTag != null) {
+                builder.append("<$BrElement>")
+                val textContext = HtmlTextEmitContext(afterCollapsibleSpace = true)
+                richParagraph.children.fastForEach { richSpan ->
+                    builder.append(
+                        decodeRichSpanToHtml(
+                            richSpan = richSpan,
+                            headingStyle = headingStyle,
+                            textContext = textContext,
+                        )
+                    )
                 }
-                openedListTagNames.clear()
-            } else if (isCloseParagraphGroup()) {
-                // Close last paragraph group tag
-                builder.append("</$lastParagraphGroupTagName>")
-                openedListTagNames.removeLastOrNull()
-
-                // We can move from nested level: 3 to nested level: 1,
-                // for this case we need to close more than one tag
-                if (
-                    isLastParagraphList &&
-                    paragraphLevel < lastParagraphGroupLevel
-                ) {
-                    repeat(lastParagraphGroupLevel - paragraphLevel) {
-                        openedListTagNames.removeLastOrNull()?.let {
-                            builder.append("</$it>")
-                        }
+                if (!nextIsLineBreakContinuation) {
+                    // A following deeper list nests inside this item: withhold </li>
+                    // like the main path instead of closing it (#736).
+                    val nextTag = nextParagraph?.let { decodeHtmlElementFromRichParagraph(it) }
+                    val nextLevel = (nextParagraph?.type as? ConfigurableListLevel)?.level ?: 0
+                    val nextNestsInThisItem = openItemTag == "li" &&
+                        (nextTag == "ol" || nextTag == "ul") &&
+                        nextLevel > openLists.size
+                    if (nextNestsInThisItem) {
+                        hostItemLevel = openLists.size
+                    } else {
+                        builder.append("</$openItemTag>")
                     }
+                    openItemTag = null
                 }
+                isLastParagraphEmpty = isParagraphEmpty
+                return@fastForEachIndexed
             }
 
-            if (isOpenParagraphGroup()) {
-                if (paragraphGroupTagName == "ol" && richParagraphType is OrderedList && richParagraphType.startFrom > 1) {
-                    builder.append("<ol start=\"${richParagraphType.startFrom}\">")
-                } else {
-                    builder.append("<$paragraphGroupTagName>")
+            if (isParagraphList) {
+                // Close deeper lists (and the withheld host items that contained them)
+                closeListsDownTo(paragraphLevel)
+
+                // Same-level list type switch (ol <-> ul): the replacement list lives in
+                // the same host item, so the host (if any) is inherited, not closed.
+                var inheritedHost: Boolean? = null
+                if (
+                    openLists.size == paragraphLevel &&
+                    openLists.isNotEmpty() &&
+                    openLists.last().tag != paragraphGroupTagName
+                ) {
+                    val closed = openLists.removeAt(openLists.lastIndex)
+                    builder.append("</${closed.tag}>")
+                    inheritedHost = closed.hasHostItem
                 }
-                openedListTagNames.add(paragraphGroupTagName)
+
+                // Open missing levels. Only the list immediately inside a withheld item
+                // has a host; other missing levels nest bare (orphan deep items). Bare
+                // nesting is invalid HTML but round-trips: the importer preserves an
+                // empty <li> that hosts a nested list as real content, so a synthetic
+                // host item would reimport as a ghost list item.
+                while (openLists.size < paragraphLevel) {
+                    val hasHost = inheritedHost
+                        ?: (hostItemLevel > 0 && openLists.size == hostItemLevel)
+                    inheritedHost = null
+                    val openingLevel = openLists.size + 1
+                    if (
+                        paragraphGroupTagName == "ol" &&
+                        richParagraphType is OrderedList &&
+                        richParagraphType.startFrom > 1 &&
+                        openingLevel == paragraphLevel
+                    ) {
+                        builder.append("<ol start=\"${richParagraphType.startFrom}\">")
+                    } else {
+                        builder.append("<$paragraphGroupTagName>")
+                    }
+                    openLists.add(OpenList(paragraphGroupTagName, hasHost))
+                }
+                hostItemLevel = 0
+            } else {
+                closeListsDownTo(0)
+                hostItemLevel = 0
             }
 
-            currentListLevel = paragraphLevel
-
-            fun isLineBreak(): Boolean {
-                if (!isParagraphEmpty)
-                    return false
-
-                if (isParagraphList && lastParagraphGroupTagName != paragraphGroupTagName)
-                    return false
-
-                return true
-            }
-
-            // Add line break if the paragraph is empty
-            if (isLineBreak()) {
+            // An empty non-list paragraph is a line break; an empty list paragraph is a
+            // real item and is emitted as <li></li>.
+            if (isParagraphEmpty && !isParagraphList) {
                 val skipAddingBr =
-                    isLastParagraphEmpty && richParagraph.isEmpty() && index == richTextState.richParagraphList.lastIndex
+                    isLastParagraphEmpty && index == paragraphs.lastIndex
 
                 if (!skipAddingBr)
                     builder.append("<$BrElement>")
             } else {
                 // Create paragraph tag name
                 val paragraphTagName =
-                    if (paragraphGroupTagName == "ol" || paragraphGroupTagName == "ul") "li"
+                    if (isParagraphList) "li"
                     else paragraphGroupTagName
 
-                // If this paragraph carries a heading, the <hN> tag is meant to imply the
-                // heading's typography. Strip the heading defaults from the paragraph CSS and the
-                // child span CSS via diff so user-added styles ride on top, but the heading
-                // visuals stay implied by the tag alone.
-                val headingStyle = richParagraph.headingStyle
+                // Create paragraph css. If the paragraph is a heading, strip the heading's
+                // base ParagraphStyle so the tag carries the visual weight on its own.
+                val effectiveParagraphStyle =
+                    if (headingStyle == HeadingStyle.Normal)
+                        richParagraph.paragraphStyle
+                    else
+                        richParagraph.paragraphStyle.diff(headingStyle.defaultParagraphStyle)
 
-                // If this paragraph came from a <br>, emit <br> + content inline
-                // without opening a new <p> tag (the previous <p> is still open)
-                if (richParagraph.isFromLineBreak && index > 0) {
-                    builder.append("<$BrElement>")
-                    richParagraph.children.fastForEach { richSpan ->
-                        builder.append(decodeRichSpanToHtml(richSpan, headingStyle = headingStyle))
-                    }
-                } else {
-                    // Create paragraph css. If the paragraph is a heading, strip the heading's
-                    // base ParagraphStyle so the tag carries the visual weight on its own.
-                    val effectiveParagraphStyle =
-                        if (headingStyle == HeadingStyle.Normal)
-                            richParagraph.paragraphStyle
-                        else
-                            richParagraph.paragraphStyle.diff(headingStyle.defaultParagraphStyle)
+                val paragraphCssMap = CssDecoder.decodeParagraphStyleToCssStyleMap(effectiveParagraphStyle)
+                val paragraphCss = CssDecoder.decodeCssStyleMap(paragraphCssMap)
 
-                    val paragraphCssMap = CssDecoder.decodeParagraphStyleToCssStyleMap(effectiveParagraphStyle)
-                    val paragraphCss = CssDecoder.decodeCssStyleMap(paragraphCssMap)
+                // Append paragraph opening tag
+                builder.append("<$paragraphTagName")
+                if (paragraphCss.isNotBlank()) builder.append(" style=\"$paragraphCss\"")
+                builder.append(">")
 
-                    // Append paragraph opening tag
-                    builder.append("<$paragraphTagName")
-                    if (paragraphCss.isNotBlank()) builder.append(" style=\"$paragraphCss\"")
-                    builder.append(">")
-
-                    // Append paragraph children
-                    richParagraph.children.fastForEach { richSpan ->
-                        builder.append(decodeRichSpanToHtml(richSpan, headingStyle = headingStyle))
-                    }
+                // Append paragraph children
+                val textContext = HtmlTextEmitContext(afterCollapsibleSpace = true)
+                richParagraph.children.fastForEach { richSpan ->
+                    builder.append(
+                        decodeRichSpanToHtml(
+                            richSpan = richSpan,
+                            headingStyle = headingStyle,
+                            textContext = textContext,
+                        )
+                    )
                 }
 
-                // Check if the next paragraph is also a <br> continuation - if so, don't close yet
-                val nextParagraph = richTextState.richParagraphList.getOrNull(index + 1)
-                val nextIsLineBreakContinuation = nextParagraph != null &&
-                    nextParagraph.isFromLineBreak &&
-                    !nextParagraph.isEmpty()
+                val nextParagraphTag = nextParagraph?.let { decodeHtmlElementFromRichParagraph(it) }
+                val nextLevel = (nextParagraph?.type as? ConfigurableListLevel)?.level ?: 0
+                val nextIsDeeperListItem = isParagraphList &&
+                    (nextParagraphTag == "ol" || nextParagraphTag == "ul") &&
+                    nextLevel > paragraphLevel
 
-                if (!nextIsLineBreakContinuation) {
-                    builder.append("</$paragraphTagName>")
+                when {
+                    // The next paragraph continues this one after a <br>
+                    nextIsLineBreakContinuation ->
+                        openItemTag = paragraphTagName
+
+                    // The next paragraph is a deeper list item: withhold </li> so the
+                    // nested list becomes a child of this item
+                    nextIsDeeperListItem ->
+                        hostItemLevel = paragraphLevel
+
+                    else ->
+                        builder.append("</$paragraphTagName>")
                 }
             }
-
-            // Save last paragraph group tag name
-            lastParagraphGroupTagName = paragraphGroupTagName
-            lastParagraphGroupLevel = paragraphLevel
 
             isLastParagraphEmpty = isParagraphEmpty
         }
 
-        // Close the remaining list tags
-        openedListTagNames.fastForEachReversed {
-            builder.append("</$it>")
-        }
-        openedListTagNames.clear()
+        // Close the remaining list tags (and any withheld host items)
+        closeListsDownTo(0)
 
         return builder.toString()
     }
+
+    /**
+     * Whitespace context threaded through span emission: true when the last emitted
+     * character is a collapsible space, so the next leading space must be
+     * entity-encoded to survive reimport (#726). Starts true at a paragraph boundary.
+     */
+    private class HtmlTextEmitContext(var afterCollapsibleSpace: Boolean)
 
     @OptIn(ExperimentalRichTextApi::class)
     private fun decodeRichSpanToHtml(
         richSpan: RichSpan,
         parentFormattingTags: List<String> = emptyList(),
         headingStyle: HeadingStyle = HeadingStyle.Normal,
+        textContext: HtmlTextEmitContext = HtmlTextEmitContext(afterCollapsibleSpace = false),
     ): String {
         val stringBuilder = StringBuilder()
 
@@ -623,17 +676,28 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
             stringBuilder.append("<$it>")
         }
 
-        // Append text
-        stringBuilder.append(KsoupEntities.encodeHtml(richSpan.text))
+        // Append text, entity-encoding a leading space that follows a collapsible one.
+        val rawText = richSpan.text
+        val encodedText = encodeHtmlText(rawText).let {
+            if (textContext.afterCollapsibleSpace && it.startsWith(' '))
+                "&#32;" + it.substring(1)
+            else
+                it
+        }
+        if (rawText.isNotEmpty()) {
+            textContext.afterCollapsibleSpace = rawText.endsWith(' ')
+        }
+        stringBuilder.append(encodedText)
 
-        // Append children, threading the heading style down so nested spans also strip their
-        // base heading visuals from inline CSS.
+        // Append children, threading the heading style down so nested spans also strip
+        // their base heading visuals from inline CSS, and the whitespace context.
         richSpan.children.fastForEach { child ->
             stringBuilder.append(
                 decodeRichSpanToHtml(
                     richSpan = child,
                     parentFormattingTags = parentFormattingTags + htmlTags,
                     headingStyle = headingStyle,
+                    textContext = textContext,
                 )
             )
         }
@@ -768,6 +832,26 @@ internal object RichTextStateHtmlParser : RichTextStateParser<String> {
             else -> richParagraph.headingStyle.htmlTag ?: "p"
         }
     }
+
+    /**
+     * Encode a text node for HTML output: escape only `&`, `<`, `>` (the full
+     * named-entities table turned "fj" into "&fjlig;", #735) and encode the second and
+     * later spaces of a run as "&#32;" so space runs survive collapsing (#726).
+     */
+    private fun encodeHtmlText(text: String): String {
+        val escaped = text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        return escaped.replace(SpaceRunRegex) { match ->
+            " " + "&#32;".repeat(match.value.length - 1)
+        }
+    }
+
+    private val SpaceRunRegex = Regex(" {2,}")
+
+    /** Numeric character references for a space: decimal, hex, and zero-padded forms. */
+    private val SpaceEntityRegex = Regex("&#0*32;|&#[xX]0*20;")
 
     /**
      * Escape a value for inclusion inside a double-quoted HTML attribute.

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/markdown/RichTextStateMarkdownParser.kt
@@ -153,6 +153,23 @@ internal object RichTextStateMarkdownParser : RichTextStateParser<String> {
                             (currentRichParagraphType as ConfigurableListLevel).level = currentListLevel
                         }
 
+                        // Interrupted lists parse as separate list nodes; seed the item
+                        // with the literal source number so the author's numbering
+                        // survives renumbering (#734).
+                        val literalNumber = node.children
+                            .firstOrNull { it.type == MarkdownTokenTypes.LIST_NUMBER }
+                            ?.getTextInNode(correctedMarkdown)
+                            ?.toString()
+                            ?.takeWhile { char -> char.isDigit() }
+                            ?.toIntOrNull()
+                        if (literalNumber != null) {
+                            currentRichParagraphType = OrderedList(
+                                number = literalNumber,
+                                initialLevel = currentListLevel,
+                                startFrom = literalNumber,
+                            )
+                        }
+
                         currentRichParagraph.type = currentRichParagraphType
                     }
 

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue716StringIndexFuzzTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue716StringIndexFuzzTest.kt
@@ -1,0 +1,252 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Pins issue #716 (StringIndexOutOfBoundsException in updateAnnotatedString): a batched
+ * IME edit shaped like deleteSurroundingText(n, 0) + commitText("\n") in one
+ * endBatchEdit used to be misclassified as an IME revert, leaving the span tree longer
+ * than the text. Deterministic repros first, then the seeded fuzz harness that
+ * surfaced the crash, kept as a wide regression net over IME-like edit sequences.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class Issue716StringIndexFuzzTest {
+
+    @Test
+    fun `ime batch edit with deletion plus newline must not crash updateAnnotatedString`() {
+        // Part 1: minimal deterministic repro. Three plain paragraphs, caret inside the
+        // middle one, then a single batched IME edit that deletes 5 characters behind the
+        // caret and inserts a newline: the new value is shorter and has one more newline,
+        // the shape the old pipeline misclassified as an IME revert.
+        run {
+            val state = RichTextState()
+            state.setText("hello world\nsecond line here\nthird line")
+            val old = state.textFieldValue.text
+
+            // Collapsed caret at 20, like a user typing inside "second line here"
+            state.onTextFieldValueChange(TextFieldValue(old, TextRange(20)))
+
+            // One endBatchEdit: deleteSurroundingText(5, 0) + commitText("\n")
+            val batched = old.removeRange(15, 20).let { it.substring(0, 15) + "\n" + it.substring(15) }
+            try {
+                state.onTextFieldValueChange(TextFieldValue(batched, TextRange(16)))
+            } catch (t: Throwable) {
+                fail(
+                    buildString {
+                        appendLine("Issue #716 reproduced with a single batched IME edit.")
+                        appendLine("Old text: \"${old.replace("\n", "\\n")}\" (len=${old.length}), caret=20")
+                        appendLine("New value: \"${batched.replace("\n", "\\n")}\" (len=${batched.length}), caret=16")
+                        appendLine("The value is shorter with one more newline, the shape the old")
+                        appendLine("pipeline misclassified as an IME revert, leaving the span tree with")
+                        appendLine("more characters than the text given to updateAnnotatedString.")
+                        appendLine()
+                        appendLine(t.stackTraceToString())
+                    },
+                )
+            }
+        }
+
+        // Part 2: seeded fuzz harness over IME-like edit sequences. This is what found
+        // the crash (seed=1). Kept as a regression net: it must stay green after the fix.
+        val scenarios = 1000
+        val stepsPerScenario = 30
+
+        for (seed in 0 until scenarios) {
+            val random = Random(seed)
+            val opLog = mutableListOf<String>()
+            val state = RichTextState()
+            val valueHistory = mutableListOf<TextFieldValue>()
+
+            fun letters(count: Int): String =
+                buildString { repeat(count) { append('a' + random.nextInt(26)) } }
+
+            fun send(desc: String, value: TextFieldValue) {
+                opLog += "$desc -> VALUE(\"${value.text.replace("\n", "\\n")}\", ${value.selection.start}, ${value.selection.end})"
+                state.onTextFieldValueChange(value)
+                valueHistory += state.textFieldValue
+            }
+
+            try {
+                val shape = random.nextInt(6)
+                when (shape) {
+                    0 -> Unit
+                    1 -> state.setText("Hello world, this is some plain text content.")
+                    2 -> state.setMarkdown("- item one\n- item two\n- item three")
+                    3 -> state.setMarkdown("1. first entry\n2. second entry\n3. third entry")
+                    4 -> state.setHtml("<p><b>Bold start</b> middle <i>italic end</i></p><ul><li>alpha</li><li>beta</li></ul>")
+                    5 -> state.setMarkdown("Title line\n\n- bullet **bold** text\n- second bullet\n\nclosing paragraph")
+                }
+                opLog += "init shape=$shape text=${state.textFieldValue.text.replace('\n', '|')}"
+
+                repeat(stepsPerScenario) {
+                    val current = state.textFieldValue.text
+                    val caret = state.textFieldValue.selection.min.coerceIn(0, current.length)
+
+                    when (random.nextInt(100)) {
+                        in 0..24 -> {
+                            // Plain typing at the caret
+                            val ch = 'a' + random.nextInt(26)
+                            send(
+                                "type '$ch'@$caret",
+                                TextFieldValue(
+                                    text = current.substring(0, caret) + ch + current.substring(caret),
+                                    selection = TextRange(caret + 1),
+                                ),
+                            )
+                        }
+
+                        in 25..32 -> {
+                            // Newline at the caret
+                            send(
+                                "newline@$caret",
+                                TextFieldValue(
+                                    text = current.substring(0, caret) + '\n' + current.substring(caret),
+                                    selection = TextRange(caret + 1),
+                                ),
+                            )
+                        }
+
+                        in 33..46 -> {
+                            // Backspace
+                            if (caret > 0) {
+                                send(
+                                    "backspace@$caret",
+                                    TextFieldValue(
+                                        text = current.substring(0, caret - 1) + current.substring(caret),
+                                        selection = TextRange(caret - 1),
+                                    ),
+                                )
+                            }
+                        }
+
+                        in 47..56 -> {
+                            // Range deletion with the selection left at the cut point
+                            if (current.length >= 2) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt((current.length - a).coerceAtMost(8)))
+                                    .coerceAtMost(current.length)
+                                send(
+                                    "deleteRange[$a,$b)",
+                                    TextFieldValue(
+                                        text = current.removeRange(a, b),
+                                        selection = TextRange(a),
+                                    ),
+                                )
+                            }
+                        }
+
+                        in 57..64 -> {
+                            // Range deletion but the IME reports an unrelated selection
+                            if (current.length >= 2) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt((current.length - a).coerceAtMost(8)))
+                                    .coerceAtMost(current.length)
+                                val newText = current.removeRange(a, b)
+                                val sel = random.nextInt(newText.length + 1)
+                                send(
+                                    "deleteRangeWeirdSel[$a,$b) sel=$sel",
+                                    TextFieldValue(text = newText, selection = TextRange(sel)),
+                                )
+                            }
+                        }
+
+                        in 65..72 -> {
+                            // Autocorrect behind the cursor: replace an earlier region with a
+                            // different-length word while the caret stays at the end
+                            if (current.isNotEmpty()) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt(6)).coerceAtMost(current.length)
+                                val repl = letters(random.nextInt(8))
+                                val newText = current.substring(0, a) + repl + current.substring(b)
+                                send(
+                                    "autocorrect[$a,$b)->'$repl'",
+                                    TextFieldValue(text = newText, selection = TextRange(newText.length)),
+                                )
+                            }
+                        }
+
+                        in 73..78 -> {
+                            // Pure selection change to a non-collapsed range
+                            if (current.isNotEmpty()) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt(current.length - a)).coerceAtMost(current.length)
+                                send("select[$a,$b]", TextFieldValue(current, TextRange(a, b)))
+                            }
+                        }
+
+                        in 79..84 -> {
+                            // Replace whatever is currently selected (insert when collapsed)
+                            val sel = state.textFieldValue.selection
+                            val repl = letters(random.nextInt(6))
+                            val newText = current.substring(0, sel.min) + repl + current.substring(sel.max)
+                            send(
+                                "replaceSel[${sel.min},${sel.max}]->'$repl'",
+                                TextFieldValue(text = newText, selection = TextRange(sel.min + repl.length)),
+                            )
+                        }
+
+                        in 85..90 -> {
+                            // IME batch edit: delete a chunk somewhere and insert a newline at
+                            // the caret in the same value (shorter text, more newlines)
+                            if (current.length >= 3) {
+                                val a = random.nextInt(current.length - 2)
+                                val b = a + 2 + random.nextInt((current.length - a - 2).coerceAtMost(6) + 1)
+                                var t = current.removeRange(a, b)
+                                val pos = random.nextInt(t.length + 1)
+                                t = t.substring(0, pos) + '\n' + t.substring(pos)
+                                send(
+                                    "imeBatch del[$a,$b)+newline@$pos",
+                                    TextFieldValue(text = t, selection = TextRange((pos + 1).coerceAtMost(t.length))),
+                                )
+                            }
+                        }
+
+                        in 91..93 -> {
+                            // Toolbar: toggle list type at the current caret
+                            if (random.nextBoolean()) state.toggleUnorderedList() else state.toggleOrderedList()
+                            opLog += "toggleList"
+                            valueHistory += state.textFieldValue
+                        }
+
+                        in 94..96 -> {
+                            // Toolbar: bold a random range
+                            if (current.isNotEmpty()) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt(current.length - a)).coerceAtMost(current.length)
+                                send("selectForBold[$a,$b]", TextFieldValue(current, TextRange(a, b)))
+                                state.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                                opLog += "toggleBold[$a,$b]"
+                                valueHistory += state.textFieldValue
+                            }
+                        }
+
+                        else -> {
+                            // Stale replay: resend a value the editor produced a few edits ago,
+                            // as a restarted input session would after replaying batched commands
+                            if (valueHistory.size >= 2) {
+                                val stale = valueHistory[random.nextInt(valueHistory.size - 1)]
+                                send("staleReplay", stale)
+                            }
+                        }
+                    }
+                }
+            } catch (t: Throwable) {
+                fail(
+                    buildString {
+                        appendLine("Fuzz crash, seed=$seed")
+                        appendLine("Op log (${opLog.size} ops):")
+                        opLog.forEach { appendLine("  $it") }
+                        appendLine("Exception: ${t.stackTraceToString()}")
+                    },
+                )
+            }
+        }
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue730SelectionRegressionTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue730SelectionRegressionTest.kt
@@ -1,0 +1,36 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+/**
+ * Regression pin for #730/#731: a pure selection change on background-free content must
+ * not invalidate the visual transformation. The #635 selection mask only changes the
+ * output when a span carries a background color; rebuilding otherwise recreates the
+ * visualTransformation mid-gesture, and Android's legacy BasicTextField re-filters on
+ * every change, fighting the selection manager.
+ */
+class Issue730SelectionRegressionTest {
+
+    @Test
+    fun `pure selection change without background spans must not rebuild the visual transformation`() {
+        val state = RichTextState()
+        state.setText("alpha beta gamma\ndelta epsilon zeta")
+        val text = state.textFieldValue.text
+
+        val before = state.visualTransformation
+
+        // Mimic the platform's long-press word selection: same text, new selection
+        state.onTextFieldValueChange(TextFieldValue(text, TextRange(6, 10)))
+
+        assertSame(
+            before,
+            state.visualTransformation,
+            "A pure selection change on content without background spans rebuilt the " +
+                "visual transformation. On Android this re-filter mid-gesture breaks " +
+                "long-press word selection, select-all and handle dragging (#730, #731).",
+        )
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextEditCorruptionFuzzTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextEditCorruptionFuzzTest.kt
@@ -10,18 +10,19 @@ import kotlin.test.Test
 import kotlin.test.fail
 
 /**
- * Fuzz round 2, with stronger oracles than round 1 (Issue716StringIndexFuzzTest):
- * every edit checks annotatedString/textFieldValue consistency and selection bounds,
- * plain-document scenarios require the text to exactly equal the committed text,
+ * Edit-pipeline fuzz harness with corruption oracles, stronger than
+ * [Issue716StringIndexFuzzTest]'s crash-only net: every edit checks
+ * annotatedString/textFieldValue consistency and selection bounds, plain-document
+ * scenarios require the text to exactly equal the committed text,
  * toHtml()/toMarkdown() run periodically, and undo/redo and emoji surrogate pairs are
  * part of the op mix. All known-bug masks except the separator-overwrite one (see
  * `knownSeparatorOverwrite` below) were removed after the fixes landed.
  */
 @OptIn(ExperimentalRichTextApi::class)
-class RichTextEditFuzzRound2Test {
+class RichTextEditCorruptionFuzzTest {
 
     @Test
-    fun `fuzz round 2 with corruption oracles must find no new issues`() {
+    fun `fuzz with corruption oracles must find no new issues`() {
         val scenarios = 600
         val stepsPerScenario = 40
 
@@ -38,7 +39,7 @@ class RichTextEditFuzzRound2Test {
             fun finding(message: String): Nothing =
                 fail(
                     buildString {
-                        appendLine("Fuzz round 2 finding, seed=$seed plainMode=$plainMode")
+                        appendLine("Corruption fuzz finding, seed=$seed plainMode=$plainMode")
                         appendLine(message)
                         appendLine("Op log (${opLog.size} ops):")
                         opLog.forEach { appendLine("  $it") }

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextEditFuzzRound2Test.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextEditFuzzRound2Test.kt
@@ -1,0 +1,303 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Fuzz round 2, with stronger oracles than round 1 (Issue716StringIndexFuzzTest):
+ * every edit checks annotatedString/textFieldValue consistency and selection bounds,
+ * plain-document scenarios require the text to exactly equal the committed text,
+ * toHtml()/toMarkdown() run periodically, and undo/redo and emoji surrogate pairs are
+ * part of the op mix. All known-bug masks except the separator-overwrite one (see
+ * `knownSeparatorOverwrite` below) were removed after the fixes landed.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextEditFuzzRound2Test {
+
+    @Test
+    fun `fuzz round 2 with corruption oracles must find no new issues`() {
+        val scenarios = 600
+        val stepsPerScenario = 40
+
+        for (seed in 0 until scenarios) {
+            val random = Random(seed)
+            val opLog = mutableListOf<String>()
+            val state = RichTextState()
+            val valueHistory = mutableListOf<TextFieldValue>()
+            val plainMode = random.nextBoolean()
+
+            fun letters(count: Int): String =
+                buildString { repeat(count) { append('a' + random.nextInt(26)) } }
+
+            fun finding(message: String): Nothing =
+                fail(
+                    buildString {
+                        appendLine("Fuzz round 2 finding, seed=$seed plainMode=$plainMode")
+                        appendLine(message)
+                        appendLine("Op log (${opLog.size} ops):")
+                        opLog.forEach { appendLine("  $it") }
+                    },
+                )
+
+            fun send(desc: String, value: TextFieldValue) {
+                opLog += "$desc -> VALUE(\"${value.text.replace("\n", "\\n")}\", ${value.selection.start}, ${value.selection.end})"
+                try {
+                    state.onTextFieldValueChange(value)
+                } catch (t: Throwable) {
+                    finding("CRASH in onTextFieldValueChange: ${t.stackTraceToString()}")
+                }
+                valueHistory += state.textFieldValue
+
+                val tfv = state.textFieldValue
+                if (tfv.text != state.annotatedString.text) {
+                    finding(
+                        "annotatedString/textFieldValue mismatch: tfv=\"${tfv.text}\" " +
+                            "annotated=\"${state.annotatedString.text}\"",
+                    )
+                }
+                if (tfv.selection.max > tfv.text.length || tfv.selection.min < 0) {
+                    finding("selection out of bounds: ${tfv.selection} for len=${tfv.text.length}")
+                }
+                if (plainMode) {
+                    val expected = value.text.replace('\n', ' ')
+                    // Known class (pinned in RichTextStateCorruptionCollectionTest): the
+                    // paragraph separator position is force-rewritten to a hardcoded space
+                    // during the rebuild, so length-preserving mismatches whose only
+                    // differences are spaces in the actual text are not new findings.
+                    val knownSeparatorOverwrite =
+                        expected.length == tfv.text.length &&
+                            expected.indices.all { expected[it] == tfv.text[it] || tfv.text[it] == ' ' }
+                    if (tfv.text != expected && knownSeparatorOverwrite) {
+                        opLog += "  (known separator overwrite, ignored)"
+                    } else if (tfv.text != expected) {
+                        finding(
+                            "plain text corruption: committed=\"${value.text.replace("\n", "\\n")}\" " +
+                                "expected=\"$expected\" actual=\"${tfv.text}\"",
+                        )
+                    }
+                }
+            }
+
+            try {
+                if (plainMode) {
+                    when (random.nextInt(3)) {
+                        1 -> state.setText("Hello world, this is some plain text content.")
+                        2 -> state.setText("alpha beta\ngamma delta\nepsilon zeta")
+                    }
+                    opLog += "init plain shape"
+                } else {
+                    when (random.nextInt(4)) {
+                        0 -> state.setMarkdown("- item one\n- item two\n- item three")
+                        1 -> state.setMarkdown("1. first entry\n2. second entry\n3. third entry")
+                        2 -> state.setHtml("<p><b>Bold start</b> middle <i>italic end</i></p><ul><li>alpha</li><li>beta</li></ul>")
+                        else -> state.setMarkdown("Title line\n\n- bullet **bold** text\n- second bullet\n\nclosing paragraph")
+                    }
+                    opLog += "init rich shape"
+                }
+                opLog += "init text=${state.textFieldValue.text.replace('\n', '|')}"
+
+                repeat(stepsPerScenario) { step ->
+                    val current = state.textFieldValue.text
+                    val caret = state.textFieldValue.selection.min.coerceIn(0, current.length)
+
+                    when (random.nextInt(100)) {
+                        in 0..21 -> {
+                            val ch = 'a' + random.nextInt(26)
+                            send(
+                                "type '$ch'@$caret",
+                                TextFieldValue(
+                                    text = current.substring(0, caret) + ch + current.substring(caret),
+                                    selection = TextRange(caret + 1),
+                                ),
+                            )
+                        }
+
+                        in 22..28 -> {
+                            send(
+                                "newline@$caret",
+                                TextFieldValue(
+                                    text = current.substring(0, caret) + '\n' + current.substring(caret),
+                                    selection = TextRange(caret + 1),
+                                ),
+                            )
+                        }
+
+                        in 29..40 -> {
+                            if (caret > 0) {
+                                send(
+                                    "backspace@$caret",
+                                    TextFieldValue(
+                                        text = current.substring(0, caret - 1) + current.substring(caret),
+                                        selection = TextRange(caret - 1),
+                                    ),
+                                )
+                            }
+                        }
+
+                        in 41..50 -> {
+                            if (current.length >= 2) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt((current.length - a).coerceAtMost(8)))
+                                    .coerceAtMost(current.length)
+                                send(
+                                    "deleteRange[$a,$b)",
+                                    TextFieldValue(
+                                        text = current.removeRange(a, b),
+                                        selection = TextRange(a),
+                                    ),
+                                )
+                            }
+                        }
+
+                        in 51..57 -> {
+                            if (current.length >= 2) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt((current.length - a).coerceAtMost(8)))
+                                    .coerceAtMost(current.length)
+                                val newText = current.removeRange(a, b)
+                                val sel = random.nextInt(newText.length + 1)
+                                send(
+                                    "deleteRangeWeirdSel[$a,$b) sel=$sel",
+                                    TextFieldValue(text = newText, selection = TextRange(sel)),
+                                )
+                            }
+                        }
+
+                        in 58..65 -> {
+                            // Word-internal autocorrect: never rewrites a range containing a
+                            // space (the separator drop corruption is already pinned)
+                            if (current.isNotEmpty()) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt(6)).coerceAtMost(current.length)
+                                if (!current.substring(a, b).contains(' ')) {
+                                    val repl = letters(random.nextInt(8))
+                                    val newText = current.substring(0, a) + repl + current.substring(b)
+                                    send(
+                                        "autocorrect[$a,$b)->'$repl'",
+                                        TextFieldValue(
+                                            text = newText,
+                                            selection = TextRange((a + repl.length).coerceAtMost(newText.length)),
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+
+                        in 66..71 -> {
+                            if (current.isNotEmpty()) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt(current.length - a)).coerceAtMost(current.length)
+                                send("select[$a,$b]", TextFieldValue(current, TextRange(a, b)))
+                            }
+                        }
+
+                        in 72..77 -> {
+                            // Replace the current selection, but skip when it contains a space
+                            val sel = state.textFieldValue.selection
+                            if (!current.substring(sel.min, sel.max).contains(' ')) {
+                                val repl = letters(random.nextInt(6))
+                                val newText = current.substring(0, sel.min) + repl + current.substring(sel.max)
+                                send(
+                                    "replaceSel[${sel.min},${sel.max}]->'$repl'",
+                                    TextFieldValue(text = newText, selection = TextRange(sel.min + repl.length)),
+                                )
+                            }
+                        }
+
+                        in 78..82 -> {
+                            // Emoji surrogate pair typed at the caret
+                            val emoji = if (random.nextBoolean()) "😀" else "👍"
+                            send(
+                                "emoji@$caret",
+                                TextFieldValue(
+                                    text = current.substring(0, caret) + emoji + current.substring(caret),
+                                    selection = TextRange(caret + emoji.length),
+                                ),
+                            )
+                        }
+
+                        in 83..86 -> {
+                            // Backspace over a full surrogate pair when one precedes the caret
+                            if (caret >= 2 && current[caret - 1].isLowSurrogate() && current[caret - 2].isHighSurrogate()) {
+                                send(
+                                    "emojiBackspace@$caret",
+                                    TextFieldValue(
+                                        text = current.removeRange(caret - 2, caret),
+                                        selection = TextRange(caret - 2),
+                                    ),
+                                )
+                            } else if (caret > 0) {
+                                send(
+                                    "backspace@$caret",
+                                    TextFieldValue(
+                                        text = current.substring(0, caret - 1) + current.substring(caret),
+                                        selection = TextRange(caret - 1),
+                                    ),
+                                )
+                            }
+                        }
+
+                        in 87..89 -> {
+                            try {
+                                if (random.nextBoolean()) state.history.undo() else state.history.redo()
+                                opLog += "undo/redo"
+                            } catch (t: Throwable) {
+                                finding("CRASH in undo/redo: ${t.stackTraceToString()}")
+                            }
+                            valueHistory += state.textFieldValue
+                        }
+
+                        in 90..92 -> {
+                            if (!plainMode) {
+                                if (random.nextBoolean()) state.toggleUnorderedList() else state.toggleOrderedList()
+                                opLog += "toggleList"
+                                valueHistory += state.textFieldValue
+                            }
+                        }
+
+                        in 93..95 -> {
+                            if (!plainMode && current.isNotEmpty()) {
+                                val a = random.nextInt(current.length)
+                                val b = (a + 1 + random.nextInt(current.length - a)).coerceAtMost(current.length)
+                                send("selectForStyle[$a,$b]", TextFieldValue(current, TextRange(a, b)))
+                                if (random.nextBoolean()) {
+                                    state.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                                    opLog += "toggleBold[$a,$b]"
+                                } else {
+                                    state.toggleCodeSpan()
+                                    opLog += "toggleCodeSpan[$a,$b]"
+                                }
+                                valueHistory += state.textFieldValue
+                            }
+                        }
+
+                        else -> {
+                            if (valueHistory.size >= 2) {
+                                val stale = valueHistory[random.nextInt(valueHistory.size - 1)]
+                                send("staleReplay", stale)
+                            }
+                        }
+                    }
+
+                    if (step % 7 == 6) {
+                        try {
+                            state.toHtml()
+                            state.toMarkdown()
+                        } catch (t: Throwable) {
+                            finding("CRASH in toHtml/toMarkdown: ${t.stackTraceToString()}")
+                        }
+                    }
+                }
+            } catch (t: Throwable) {
+                if (t is AssertionError) throw t
+                finding("CRASH outside send: ${t.stackTraceToString()}")
+            }
+        }
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextHtmlRoundTripFuzzTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextHtmlRoundTripFuzzTest.kt
@@ -1,0 +1,199 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Fuzz round 3: HTML export round-trip stability. Builds documents through random edits
+ * and style toggles, then checks: toHtml() must not crash, setHtml(toHtml()) must
+ * preserve the visible text, and toHtml -> setHtml -> toHtml must be idempotent (one
+ * normalization pass allowed). Distinct failure classes get deterministic pins in
+ * RichTextStateCorruptionCollectionTest.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextHtmlRoundTripFuzzTest {
+
+    @Test
+    fun `html export round trip must preserve text and be idempotent`() {
+        val scenarios = 400
+        val stepsPerScenario = 12
+
+        for (seed in 0 until scenarios) {
+            val random = Random(seed)
+            val opLog = mutableListOf<String>()
+            val state = RichTextState()
+
+            fun letters(count: Int): String =
+                buildString { repeat(count) { append('a' + random.nextInt(26)) } }
+
+            fun finding(message: String): Nothing =
+                fail(
+                    buildString {
+                        appendLine("Round-trip finding, seed=$seed")
+                        appendLine(message)
+                        appendLine("Op log (${opLog.size} ops):")
+                        opLog.forEach { appendLine("  $it") }
+                    },
+                )
+
+            try {
+                when (random.nextInt(7)) {
+                    0 -> state.setText("plain text content here")
+                    1 -> state.setMarkdown("- item one\n- item two")
+                    2 -> state.setMarkdown("1. first\n2. second\n3. third")
+                    3 -> state.setHtml("<p>before <b>bold</b> after</p><p>second paragraph</p>")
+                    4 -> Unit
+                    // #734 shape: ordered items with continuation text and blank lines
+                    5 -> state.setMarkdown(
+                        "intro line\n\n1. first title\ncontinuation text here\n\n" +
+                            "2. second title\n\n3. third title\nmore continuation",
+                    )
+                    // #736 shape: nested list levels (built via the level API below)
+                    6 -> {
+                        state.setMarkdown("1. aa\n2. bb\n3. cc\n4. dd\n5. ee")
+                        val t = state.textFieldValue.text
+                        state.onTextFieldValueChange(TextFieldValue(t, TextRange(t.indexOf("cc") + 1)))
+                        state.increaseListLevel()
+                        val t2 = state.textFieldValue.text
+                        state.onTextFieldValueChange(TextFieldValue(t2, TextRange(t2.indexOf("dd") + 1)))
+                        state.increaseListLevel()
+                        state.increaseListLevel()
+                    }
+                }
+                opLog += "init text=${state.textFieldValue.text.replace('\n', '|')}"
+
+                repeat(stepsPerScenario) {
+                    val text = state.textFieldValue.text
+                    val caret = state.selection.min.coerceIn(0, text.length)
+
+                    when (random.nextInt(10)) {
+                        in 0..3 -> {
+                            val ch = 'a' + random.nextInt(26)
+                            opLog += "type '$ch'@$caret"
+                            state.onTextFieldValueChange(
+                                TextFieldValue(
+                                    text.substring(0, caret) + ch + text.substring(caret),
+                                    TextRange(caret + 1),
+                                ),
+                            )
+                        }
+
+                        4 -> {
+                            opLog += "space@$caret"
+                            state.onTextFieldValueChange(
+                                TextFieldValue(
+                                    text.substring(0, caret) + ' ' + text.substring(caret),
+                                    TextRange(caret + 1),
+                                ),
+                            )
+                        }
+
+                        5 -> {
+                            opLog += "newline@$caret"
+                            state.onTextFieldValueChange(
+                                TextFieldValue(
+                                    text.substring(0, caret) + '\n' + text.substring(caret),
+                                    TextRange(caret + 1),
+                                ),
+                            )
+                        }
+
+                        in 6..7 -> {
+                            if (text.isNotEmpty()) {
+                                val a = random.nextInt(text.length)
+                                val b = (a + 1 + random.nextInt(text.length - a)).coerceAtMost(text.length)
+                                opLog += "style[$a,$b]"
+                                state.onTextFieldValueChange(TextFieldValue(text, TextRange(a, b)))
+                                when (random.nextInt(4)) {
+                                    0 -> state.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                                    1 -> state.toggleSpanStyle(SpanStyle(fontStyle = FontStyle.Italic))
+                                    2 -> state.toggleCodeSpan()
+                                    3 -> state.addLinkToSelection("https://example.com/${letters(4)}")
+                                }
+                            }
+                        }
+
+                        8 -> {
+                            when (random.nextInt(4)) {
+                                0 -> {
+                                    opLog += "toggleUnorderedList"
+                                    state.toggleUnorderedList()
+                                }
+                                1 -> {
+                                    opLog += "toggleOrderedList"
+                                    state.toggleOrderedList()
+                                }
+                                2 -> {
+                                    opLog += "increaseListLevel"
+                                    state.increaseListLevel()
+                                }
+                                else -> {
+                                    opLog += "decreaseListLevel"
+                                    state.decreaseListLevel()
+                                }
+                            }
+                        }
+
+                        else -> {
+                            if (text.length >= 2) {
+                                val a = random.nextInt(text.length)
+                                val b = (a + 1 + random.nextInt((text.length - a).coerceAtMost(5)))
+                                    .coerceAtMost(text.length)
+                                opLog += "delete[$a,$b)"
+                                state.onTextFieldValueChange(
+                                    TextFieldValue(text.removeRange(a, b), TextRange(a)),
+                                )
+                            }
+                        }
+                    }
+                }
+
+                val text0 = state.textFieldValue.text
+                val html1 = state.toHtml()
+
+                val state2 = RichTextState()
+                state2.setHtml(html1)
+                val text1 = state2.textFieldValue.text
+                // Known pre-existing ambiguity (not a pinned finding): the number of
+                // trailing empty lines is not bijective through the <br>/implicit
+                // paragraph mapping at document end. Content must match exactly;
+                // trailing paragraph separators are tolerated.
+                if (text1.trimEnd(' ') != text0.trimEnd(' ')) {
+                    finding(
+                        "round-trip changed the visible text:\n" +
+                            "  before=\"${text0.replace("\n", "\\n")}\"\n" +
+                            "  after =\"${text1.replace("\n", "\\n")}\"\n" +
+                            "  html  =$html1",
+                    )
+                }
+
+                val html2 = state2.toHtml()
+                val state3 = RichTextState()
+                state3.setHtml(html2)
+                val html3 = state3.toHtml()
+                if (html3 != html2) {
+                    finding(
+                        "html round-trip is not idempotent:\n  html2=$html2\n  html3=$html3",
+                    )
+                }
+            } catch (t: Throwable) {
+                if (t is AssertionError) throw t
+                // Edit-pipeline crashes (tree/text desync families) are already pinned
+                // by rounds 1 and 2; this round hunts the export surface, so skip the
+                // scenario when the crash came from onTextFieldValueChange.
+                val isKnownEditPipelineCrash = t is IndexOutOfBoundsException &&
+                    t.stackTraceToString().contains("onTextFieldValueChange")
+                if (!isKnownEditPipelineCrash) {
+                    finding("CRASH: ${t.stackTraceToString()}")
+                }
+            }
+        }
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextHtmlRoundTripFuzzTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextHtmlRoundTripFuzzTest.kt
@@ -186,8 +186,9 @@ class RichTextHtmlRoundTripFuzzTest {
             } catch (t: Throwable) {
                 if (t is AssertionError) throw t
                 // Edit-pipeline crashes (tree/text desync families) are already pinned
-                // by rounds 1 and 2; this round hunts the export surface, so skip the
-                // scenario when the crash came from onTextFieldValueChange.
+                // by Issue716StringIndexFuzzTest and RichTextEditCorruptionFuzzTest;
+                // this harness hunts the export surface, so skip the scenario when the
+                // crash came from onTextFieldValueChange.
                 val isKnownEditPipelineCrash = t is IndexOutOfBoundsException &&
                     t.stackTraceToString().contains("onTextFieldValueChange")
                 if (!isKnownEditPipelineCrash) {

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateCorruptionCollectionTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateCorruptionCollectionTest.kt
@@ -1,0 +1,374 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Deterministic pins for crashes and content corruptions found by fuzzing the edit
+ * pipeline (#716 family). One test per finding.
+ */
+class RichTextStateCorruptionCollectionTest {
+
+    private fun orderedNumbers(text: String): List<Int> =
+        Regex("(\\d+)\\. ").findAll(text).map { it.groupValues[1].toInt() }.toList()
+
+    /**
+     * A batched IME edit (delete + commit "\n" in one endBatchEdit) inside an ordered
+     * list item must go through the regular split, which renumbers.
+     */
+    @Test
+    fun `batched delete plus newline inside an ordered list item must keep numbering sequential`() {
+        val state = RichTextState()
+        state.setMarkdown("1. first entry\n2. second entry\n3. third entry")
+        val old = state.textFieldValue.text // "1. first entry 2. second entry 3. third entry"
+
+        // Collapsed caret after "second" (index 24), like a user typing inside item 2
+        state.onTextFieldValueChange(TextFieldValue(old, TextRange(24)))
+
+        // One endBatchEdit: deleteSurroundingText(5, 0) + commitText("\n")
+        val batched = old.removeRange(19, 24).let { it.substring(0, 19) + "\n" + it.substring(19) }
+        state.onTextFieldValueChange(TextFieldValue(batched, TextRange(20)))
+
+        val text = state.textFieldValue.text
+        val numbers = orderedNumbers(text)
+        assertEquals(
+            (1..numbers.size).toList(),
+            numbers,
+            "Ordered list numbers must stay sequential after the split, text=\"$text\"",
+        )
+    }
+
+    @Test
+    fun `deleting a middle ordered list item must renumber the following items`() {
+        val state = RichTextState()
+        state.setMarkdown("1. aa\n2. bb\n3. cc")
+        val old = state.textFieldValue.text // "1. aa 2. bb 3. cc"
+
+        state.onTextFieldValueChange(TextFieldValue(old, TextRange(6)))
+        // Delete "2. bb " -> range [6,12)
+        state.onTextFieldValueChange(TextFieldValue(old.removeRange(6, 12), TextRange(6)))
+
+        val text = state.textFieldValue.text
+        assertEquals(
+            listOf(1, 2),
+            orderedNumbers(text),
+            "Remaining items must be renumbered 1, 2, text=\"$text\"",
+        )
+    }
+
+    /**
+     * A same-length replacement spanning the virtual paragraph separator (the space
+     * between paragraphs in textFieldValue.text) must not drop the committed character.
+     */
+    @Test
+    fun `same length replacement across the paragraph separator must not drop characters`() {
+        val state = RichTextState()
+        state.setText("abcdef\nghijkl")
+        val old = state.textFieldValue.text // "abcdef ghijkl"
+
+        state.onTextFieldValueChange(TextFieldValue(old, TextRange(old.length)))
+
+        // Autocorrect-style same-length replacement of "f g" (range [5,8)) with "xyz"
+        val incoming = old.substring(0, 5) + "xyz" + old.substring(8)
+        state.onTextFieldValueChange(TextFieldValue(incoming, TextRange(8)))
+
+        assertEquals(
+            incoming,
+            state.textFieldValue.text,
+            "The committed text must be preserved",
+        )
+    }
+
+    /**
+     * List prefixes are atomic: a selection covering part of the first prefix through
+     * the second item's first content char collapses both items into one, and the typed
+     * character lands next to the kept "b" ("1. xb"). Must never crash or desync.
+     */
+    @Test
+    fun `typing over a selection that starts inside a list prefix must not crash`() {
+        val state = RichTextState()
+        state.setMarkdown("1. aa\n2. bb")
+        val old = state.textFieldValue.text // "1. aa 2. bb", prefixes [0,3) and [6,9)
+
+        // Selection from inside the first prefix into the second item's content
+        state.onTextFieldValueChange(TextFieldValue(old, TextRange(2, 10)))
+
+        // Typing replaces the selection
+        val incoming = old.substring(0, 2) + "x" + old.substring(10)
+        state.onTextFieldValueChange(TextFieldValue(incoming, TextRange(3)))
+
+        assertEquals(
+            state.annotatedString.text,
+            state.textFieldValue.text,
+            "Tree and text field value must stay in sync",
+        )
+        assertEquals("1. xb", state.textFieldValue.text)
+    }
+
+    @Test
+    fun `replacing a selection spanning a list prefix must preserve the committed text`() {
+        val state = RichTextState()
+        state.setMarkdown("1. aa\n2. bb")
+        val old = state.textFieldValue.text // "1. aa 2. bb"
+
+        state.onTextFieldValueChange(TextFieldValue(old, TextRange(3, 10)))
+
+        val incoming = old.substring(0, 3) + "xyzxyzxyz" + old.substring(10)
+        state.onTextFieldValueChange(TextFieldValue(incoming, TextRange(12)))
+
+        assertEquals(
+            incoming,
+            state.textFieldValue.text,
+            "The committed replacement must be preserved",
+        )
+    }
+
+    /**
+     * A deletion clipping the inside of a list prefix removes the whole prefix and
+     * demotes the item (prefixes are atomic): "1aa 2. bb" becomes "aa 1. bb".
+     */
+    @Test
+    fun `deletion clipping inside a list prefix must demote consistently`() {
+        val state = RichTextState()
+        state.setMarkdown("1. aa\n2. bb")
+        val old = state.textFieldValue.text // "1. aa 2. bb"
+
+        val committed = old.removeRange(1, 3)
+        state.onTextFieldValueChange(TextFieldValue(committed, TextRange(1)))
+
+        assertEquals(
+            state.annotatedString.text,
+            state.textFieldValue.text,
+            "Tree and text field value must stay in sync",
+        )
+        assertEquals("aa 1. bb", state.textFieldValue.text)
+    }
+
+    /**
+     * The values look arbitrary because they were delta-debugged out of a longer fuzz
+     * session, but each one is a legal IME callback; the rebuild must not crash.
+     */
+    @Test
+    fun `repeated ime values clipping list prefixes must not crash the rebuild`() {
+        val state = RichTextState()
+        state.setMarkdown("1. first entry\n2. second entry\n3. third entry")
+
+        state.onTextFieldValueChange(
+            TextFieldValue("1rst entry 2. second entry 3. third entryq", TextRange(1)),
+        )
+        state.onTextFieldValueChange(
+            TextFieldValue("👍rst entry 1. sen 2. third entryq", TextRange(6, 8)),
+        )
+        state.onTextFieldValueChange(
+            TextFieldValue("👍rst \nentry 1. sen 2. third entryq", TextRange(7)),
+        )
+        state.onTextFieldValueChange(
+            TextFieldValue("👍rst  . sird entryq", TextRange(7)),
+        )
+    }
+
+    /**
+     * A newline split followed by an insertion at the new paragraph's start must keep
+     * the span tree consistent; a later small deletion must not no-op and crash.
+     */
+    @Test
+    fun `deletion after a newline split and an insertion must not desync the span tree`() {
+        val state = RichTextState()
+        state.setHtml("<p><b>Bold start</b> middle <i>italic end</i></p><ul><li>alpha</li><li>beta</li></ul>")
+
+        // Large deletion, "u\n" typed at index 1, "qw" typed at the new paragraph's
+        // start, then a 2-char deletion inside it
+        state.onTextFieldValueChange(
+            TextFieldValue("ostartmiddlic end • alpha • beta", TextRange(1)),
+        )
+        state.onTextFieldValueChange(
+            TextFieldValue("ou\nstartmiddlic end • alpha • beta", TextRange(3)),
+        )
+        state.onTextFieldValueChange(
+            TextFieldValue("ou qwstartmiddlic end • alpha • beta", TextRange(5)),
+        )
+        state.onTextFieldValueChange(
+            TextFieldValue("ou qwstartmilic end • alpha • beta", TextRange(12)),
+        )
+    }
+
+    // #726
+    @Test
+    fun `html round trip must preserve consecutive spaces`() {
+        val state = RichTextState()
+        state.setText("a  b")
+
+        val html = state.toHtml()
+        val reloaded = RichTextState()
+        reloaded.setHtml(html)
+
+        assertEquals(
+            state.textFieldValue.text,
+            reloaded.textFieldValue.text,
+            "Round trip collapsed consecutive spaces, html=$html",
+        )
+    }
+
+    /**
+     * The document is built through edits (not setHtml) because setHtml used to drop
+     * empty items on the way in as well.
+     */
+    @Test
+    fun `empty list items must survive an html round trip`() {
+        val state = RichTextState()
+        state.setMarkdown("- item one")
+        val text = state.textFieldValue.text // "• item one"
+        state.onTextFieldValueChange(TextFieldValue(text, TextRange(text.length)))
+        // Enter at the end of the item creates a new, empty list item
+        state.onTextFieldValueChange(TextFieldValue("$text\n", TextRange(text.length + 1)))
+        val originalText = state.textFieldValue.text
+
+        val html = state.toHtml()
+        val reloaded = RichTextState()
+        reloaded.setHtml(html)
+
+        assertEquals(
+            originalText,
+            reloaded.textFieldValue.text,
+            "Round trip dropped the empty list item, html=$html",
+        )
+    }
+
+    // #735: the full named-entities table encodes "fj" as "&fjlig;"
+    @Test
+    fun `text containing the letter pair fj must survive an html round trip`() {
+        val state = RichTextState()
+        state.setText("fjord")
+
+        val html = state.toHtml()
+        val reloaded = RichTextState()
+        reloaded.setHtml(html)
+
+        assertEquals(
+            "fjord",
+            reloaded.textFieldValue.text,
+            "Round trip mangled 'fj', html=$html",
+        )
+    }
+
+    /**
+     * Asserts encode idempotence: reimporting "<li>a<br>b</li>" used to derail list
+     * reconstruction and the next encode emitted malformed HTML.
+     */
+    @Test
+    fun `line break inside a list item must survive an html round trip`() {
+        val state = RichTextState()
+        state.setHtml("<ul><li>a<br>b</li></ul>")
+
+        val html2 = state.toHtml()
+        val reloaded = RichTextState()
+        reloaded.setHtml(html2)
+        val html3 = reloaded.toHtml()
+
+        assertEquals(
+            html2,
+            html3,
+            "Re-encoding the round-tripped list item changed (and malformed) the HTML",
+        )
+    }
+
+    // #734
+    @Test
+    fun `markdown ordered list with continuation text must keep its numbering`() {
+        val state = RichTextState()
+        state.setMarkdown(
+            """
+            Hello! This is a notice.
+
+            1. First item title
+            This is the first item description.
+
+            2. Second item title
+
+            3. Third item title
+            This is the third item description.
+            """.trimIndent(),
+        )
+
+        val text = state.textFieldValue.text
+        assertEquals(
+            true,
+            text.contains("2. Second item title") && text.contains("3. Third item title"),
+            "Ordered list numbering was reset, text=\"${text.replace("\n", "\\n")}\"",
+        )
+    }
+
+    /**
+     * #736: asserts HTML structure rather than a round trip because the library's own
+     * parser reimports the malformed sibling-nested shape losslessly; only external
+     * consumers (browsers) see the breakage.
+     */
+    @Test
+    fun `nested list levels must export well formed html`() {
+        val state = RichTextState()
+        state.setMarkdown("1. a\n2. b\n3. c\n4. d\n5. e")
+
+        fun caretOn(content: Char) {
+            val text = state.textFieldValue.text
+            val index = text.indexOf(content)
+            state.onTextFieldValueChange(
+                TextFieldValue(text, TextRange(index + 1)),
+            )
+        }
+
+        caretOn('c')
+        state.increaseListLevel() // c -> level 2
+        caretOn('d')
+        state.increaseListLevel()
+        state.increaseListLevel() // d -> level 3
+
+        val html = state.toHtml()
+
+        assertEquals(
+            false,
+            html.contains("</li><ol") || html.contains("</ol><ol"),
+            "Nested lists must nest inside their parent <li> and must not split the " +
+                "top-level list, html=$html",
+        )
+    }
+
+    /**
+     * Unordered flavor of the #736 defect; same structure-based assertion.
+     */
+    @Test
+    fun `unordered list nesting must export well formed html`() {
+        val state = RichTextState()
+        state.setMarkdown("- a\n- b")
+        val text = state.textFieldValue.text
+        state.onTextFieldValueChange(
+            TextFieldValue(text, TextRange(text.indexOf('b') + 1)),
+        )
+        state.increaseListLevel() // b -> level 2
+
+        val html = state.toHtml()
+
+        assertEquals(
+            false,
+            html.contains("</li><ul") || html.contains("</ul><ul"),
+            "Nested unordered lists must nest inside their parent <li>, html=$html",
+        )
+    }
+
+    @Test
+    fun `undo after typing into a loaded document must revert only the typing`() {
+        val state = RichTextState()
+        state.setText("base text")
+        val loaded = state.textFieldValue.text
+
+        state.onTextFieldValueChange(TextFieldValue("$loaded!", TextRange(loaded.length + 1)))
+        state.history.undo()
+
+        assertEquals(
+            loaded,
+            state.textFieldValue.text,
+            "Undo must revert the typed character, not the whole loaded document",
+        )
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateTest.kt
@@ -1751,10 +1751,14 @@ class RichTextStateTest {
             )
         )
 
+        // Type "World" into the second item, deriving the value from the live state
+        // text the way a real text field reports it.
+        val textAfterEnter = state.textFieldValue.text
+        assertEquals("1. Hello  2. ", textAfterEnter)
         state.onTextFieldValueChange(
             TextFieldValue(
-                text = "1. Hello 2. World",
-                selection = TextRange(17),
+                text = textAfterEnter + "World",
+                selection = TextRange(textAfterEnter.length + 5),
             )
         )
 

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateVisualTransformationRaceTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateVisualTransformationRaceTest.kt
@@ -1,0 +1,606 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.trigger.Trigger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Tests for the `visualTransformation` snapshot fix in `updateAnnotatedString`:
+ * a captured lambda must return the annotatedString it was paired with, not a live
+ * read, and `visualTransformation.filter(...)` must always match
+ * `textFieldValue.text.length` (the invariant Compose validates at scroll-measure
+ * time, #717).
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextStateVisualTransformationRaceTest {
+
+    // ---- Helpers ----
+
+    private fun RichTextState.transformedLength(): Int {
+        val input = AnnotatedString(textFieldValue.text)
+        return visualTransformation.filter(input).text.length
+    }
+
+    private fun RichTextState.assertVtInvariant(label: String) {
+        val tfvLen = textFieldValue.text.length
+        val transformedLen = transformedLength()
+        if (tfvLen != transformedLen) {
+            fail(
+                "VT/textFieldValue length mismatch ($label): " +
+                    "textFieldValue.text.length=$tfvLen, " +
+                    "visualTransformation.filter(...).text.length=$transformedLen, " +
+                    "annotatedString.length=${annotatedString.text.length}"
+            )
+        }
+        assertEquals(
+            tfvLen,
+            annotatedString.text.length,
+            "annotatedString/textFieldValue length mismatch ($label)"
+        )
+    }
+
+    private fun RichTextState.simulateTyping(text: String) {
+        for (char in text) {
+            val current = annotatedString.text
+            val pos = selection.min
+            val newText = current.substring(0, pos) + char + current.substring(pos)
+            onTextFieldValueChange(
+                TextFieldValue(text = newText, selection = TextRange(pos + 1))
+            )
+        }
+    }
+
+    private fun RichTextState.simulateEnter() {
+        val current = annotatedString.text
+        val pos = selection.min
+        val newText = current.substring(0, pos) + "\n" + current.substring(pos)
+        onTextFieldValueChange(
+            TextFieldValue(text = newText, selection = TextRange(pos + 1))
+        )
+    }
+
+    private fun RichTextState.simulateBackspace() {
+        val current = annotatedString.text
+        val pos = selection.min
+        if (pos <= 0) return
+        val newText = current.substring(0, pos - 1) + current.substring(pos)
+        onTextFieldValueChange(
+            TextFieldValue(text = newText, selection = TextRange(pos - 1))
+        )
+    }
+
+    // ====================================================================
+    // 1. Direct race verification: captured VT must return paired snapshot
+    // ====================================================================
+
+    @Test
+    fun capturedVisualTransformationReturnsPairedSnapshotAfterSubsequentSetHtml() {
+        val state = RichTextState()
+        state.setHtml("<p>Hello world example</p>")
+
+        val captured = state.visualTransformation
+        val pairedTextFieldValue = state.textFieldValue
+        val pairedLength = pairedTextFieldValue.text.length
+
+        // Mutate state. After this, state.annotatedString has a different length
+        // than the snapshot the captured VT was paired with.
+        state.setHtml("<p>X</p>")
+        assertTrue(
+            state.annotatedString.text.length != pairedLength,
+            "Test setup: subsequent setHtml must change annotatedString length"
+        )
+
+        // Invoking the captured lambda with its paired textFieldValue must produce
+        // a transformed string of the original paired length, not the current.
+        val transformed = captured.filter(AnnotatedString(pairedTextFieldValue.text))
+        assertEquals(
+            pairedLength,
+            transformed.text.length,
+            "Captured visualTransformation must return its paired snapshot length, " +
+                "not whatever state.annotatedString currently holds. " +
+                "If this fails, the lambda is doing a live read of state.annotatedString " +
+                "and the OffsetMapping.Identity race is back."
+        )
+    }
+
+    @Test
+    fun capturedVisualTransformationStaysPairedAcrossManyMutations() {
+        val state = RichTextState()
+        state.setHtml("<ol><li>One</li><li>Two</li><li>Three</li></ol>")
+
+        val captured = state.visualTransformation
+        val pairedTextFieldValue = state.textFieldValue
+        val pairedLength = pairedTextFieldValue.text.length
+
+        // Drive a long sequence of mutations. The captured VT, called with its
+        // paired textFieldValue, must keep returning the original length.
+        repeat(20) { i ->
+            state.setHtml("<p>Iteration $i with extra text $i $i $i $i</p>")
+            state.setMarkdown("- a\n- b\n- c\n- d\n- e\n")
+            state.setText("plain text $i")
+        }
+
+        val transformed = captured.filter(AnnotatedString(pairedTextFieldValue.text))
+        assertEquals(
+            pairedLength,
+            transformed.text.length,
+            "Captured VT lost its paired snapshot during heavy mutations"
+        )
+    }
+
+    @Test
+    fun capturedVisualTransformationStaysPairedAcrossListBoundaryRenumbering() {
+        // The 9 -> 10 renumbering changes prefix length for paragraph 10 from
+        // "10. " (4 chars) compared to "9. " (3 chars). If the captured VT did a
+        // live read it would suddenly disagree on length.
+        val state = RichTextState()
+        state.setHtml("<ol>" + (1..9).joinToString("") { "<li>Item</li>" } + "</ol>")
+
+        val captured = state.visualTransformation
+        val pairedTextFieldValue = state.textFieldValue
+        val pairedLength = pairedTextFieldValue.text.length
+
+        // Push past the 9 -> 10 boundary
+        state.selection = TextRange(state.annotatedString.text.length)
+        state.simulateEnter()
+        state.simulateTyping("Item 10")
+
+        val transformed = captured.filter(AnnotatedString(pairedTextFieldValue.text))
+        assertEquals(pairedLength, transformed.text.length)
+    }
+
+    // ====================================================================
+    // 2. Invariant under content-shape variation
+    // ====================================================================
+
+    @Test
+    fun invariantHoldsForEmptyState() {
+        val state = RichTextState()
+        state.assertVtInvariant("fresh state")
+    }
+
+    @Test
+    fun invariantHoldsForPlainText() {
+        val state = RichTextState()
+        state.setText("Just a single line of plain text")
+        state.assertVtInvariant("setText plain")
+    }
+
+    @Test
+    fun invariantHoldsForMultiParagraphPlainHtml() {
+        val state = RichTextState()
+        state.setHtml("<p>One</p><p>Two</p><p>Three</p><p>Four</p>")
+        state.assertVtInvariant("multi paragraph html")
+    }
+
+    @Test
+    fun invariantHoldsForInlineStyledHtml() {
+        val state = RichTextState()
+        state.setHtml(
+            "<p>Mixed <b>bold</b> and <i>italic</i> and " +
+                "<u>underline</u> and <b><i>bold-italic</i></b> together.</p>"
+        )
+        state.assertVtInvariant("inline styled html")
+    }
+
+    @Test
+    fun invariantHoldsForAllHeadingLevels() {
+        val state = RichTextState()
+        state.setHtml(
+            "<h1>H1</h1><h2>H2</h2><h3>H3</h3>" +
+                "<h4>H4</h4><h5>H5</h5><h6>H6</h6><p>Body</p>"
+        )
+        state.assertVtInvariant("all heading levels")
+    }
+
+    @Test
+    fun invariantHoldsForOrderedListShortAndLong() {
+        val state = RichTextState()
+        state.setHtml("<ol>" + (1..5).joinToString("") { "<li>Item $it</li>" } + "</ol>")
+        state.assertVtInvariant("short ordered list")
+
+        state.setHtml("<ol>" + (1..120).joinToString("") { "<li>Item $it</li>" } + "</ol>")
+        state.assertVtInvariant("long ordered list crossing 99->100")
+    }
+
+    @Test
+    fun invariantHoldsForUnorderedList() {
+        val state = RichTextState()
+        state.setHtml("<ul><li>A</li><li>B</li><li>C</li><li>D</li></ul>")
+        state.assertVtInvariant("unordered list")
+    }
+
+    @Test
+    fun invariantHoldsForNestedMixedLists() {
+        val state = RichTextState()
+        state.setHtml(
+            "<ol>" +
+                "<li>Top one<ul><li>a</li><li>b</li></ul></li>" +
+                "<li>Top two<ol><li>i</li><li>ii</li></ol></li>" +
+                "<li>Top three</li>" +
+                "</ol>"
+        )
+        state.assertVtInvariant("nested mixed lists")
+    }
+
+    @Test
+    fun invariantHoldsForLinks() {
+        val state = RichTextState()
+        state.setHtml(
+            "<p>Visit <a href=\"https://example.com\">example.com</a> or " +
+                "<a href=\"https://kotlinlang.org\">kotlinlang.org</a>.</p>"
+        )
+        state.assertVtInvariant("links")
+    }
+
+    @Test
+    fun invariantHoldsForInlineCodeSpans() {
+        val state = RichTextState()
+        state.setHtml("<p>Use <code>val x = 1</code> and <code>fun foo()</code>.</p>")
+        state.assertVtInvariant("inline code spans")
+    }
+
+    @Test
+    fun invariantHoldsForMentionTokens() {
+        val state = RichTextState()
+        state.registerTrigger(
+            Trigger(
+                id = "mention",
+                char = '@',
+                style = { SpanStyle(fontWeight = FontWeight.Medium) },
+            )
+        )
+        state.setMarkdown(
+            "Hi [@alice](trigger:mention:u-alice), " +
+                "[@bob](trigger:mention:u-bob), and " +
+                "[@carol](trigger:mention:u-carol)!"
+        )
+        state.assertVtInvariant("mention tokens")
+    }
+
+    @Test
+    fun invariantHoldsForHashtagTokens() {
+        val state = RichTextState()
+        state.registerTrigger(Trigger(id = "hashtag", char = '#'))
+        state.setMarkdown(
+            "[#release](trigger:hashtag:release) " +
+                "[#design](trigger:hashtag:design) " +
+                "[#bug](trigger:hashtag:bug)"
+        )
+        state.assertVtInvariant("hashtag tokens")
+    }
+
+    @Test
+    fun invariantHoldsForEmptyAndTrailingParagraphs() {
+        val state = RichTextState()
+        state.setHtml("<p>One</p><p></p><p>Three</p><p></p>")
+        state.assertVtInvariant("empty and trailing paragraphs")
+    }
+
+    @Test
+    fun invariantHoldsForLongFlowingParagraph() {
+        val state = RichTextState()
+        state.setHtml(
+            "<p>" +
+                ("This is a long paragraph that wraps and wraps. ".repeat(40)) +
+                "</p>"
+        )
+        state.assertVtInvariant("long flowing paragraph")
+    }
+
+    @Test
+    fun invariantHoldsForKitchenSinkContent() {
+        val state = RichTextState()
+        state.registerTrigger(Trigger(id = "mention", char = '@'))
+        state.registerTrigger(Trigger(id = "hashtag", char = '#'))
+        state.setMarkdown(
+            "# Kitchen sink\n\n" +
+                "Intro from [@mohamed](trigger:mention:u-m) " +
+                "tagging [#release](trigger:hashtag:release).\n\n" +
+                "## Numbered\n\n" +
+                (1..12).joinToString("\n") { "$it. Item $it" } + "\n\n" +
+                "## Bullets\n\n" +
+                "- Alpha **bold**\n- Beta *italic*\n- Gamma `code`\n\n" +
+                "Closing line."
+        )
+        state.assertVtInvariant("kitchen sink markdown")
+    }
+
+    // ====================================================================
+    // 3. Invariant after individual mutation paths
+    // ====================================================================
+
+    @Test
+    fun invariantHoldsThroughTypingIntoOrderedList() {
+        val state = RichTextState()
+        state.setHtml("<ol><li>Start</li></ol>")
+        state.assertVtInvariant("initial list")
+
+        state.selection = TextRange(state.annotatedString.text.length)
+        state.simulateTyping(" and more text here")
+        state.assertVtInvariant("after typing in ordered list")
+    }
+
+    @Test
+    fun invariantHoldsThroughEnterCreatingNewListItems() {
+        val state = RichTextState()
+        state.setHtml("<ol><li>First</li></ol>")
+        state.assertVtInvariant("initial")
+
+        for (i in 2..6) {
+            state.selection = TextRange(state.annotatedString.text.length)
+            state.simulateEnter()
+            state.assertVtInvariant("after Enter for item $i")
+            state.simulateTyping("Item $i")
+            state.assertVtInvariant("after typing item $i")
+        }
+    }
+
+    @Test
+    fun invariantHoldsThroughBackspaceAtListBoundary() {
+        val state = RichTextState()
+        state.setHtml("<ol><li>Hello</li><li>World</li></ol>")
+        state.assertVtInvariant("initial")
+
+        val text = state.annotatedString.text
+        val helloEnd = text.indexOf("Hello") + "Hello".length
+        state.selection = TextRange(helloEnd + 1)
+        val newText = text.substring(0, helloEnd) + text.substring(helloEnd + 1)
+        state.onTextFieldValueChange(
+            TextFieldValue(text = newText, selection = TextRange(helloEnd))
+        )
+        state.assertVtInvariant("after backspace at list boundary")
+    }
+
+    @Test
+    fun invariantHoldsThroughSelectAllReplace() {
+        val state = RichTextState()
+        state.setHtml(
+            "<p>" + "A".repeat(50) + " <b>" + "B".repeat(50) + "</b> " +
+                "<i>" + "C".repeat(50) + "</i></p>"
+        )
+        state.assertVtInvariant("initial styled text")
+
+        val full = state.annotatedString.text
+        state.selection = TextRange(0, full.length)
+        state.onTextFieldValueChange(TextFieldValue(text = "Replaced", selection = TextRange(8)))
+        state.assertVtInvariant("after select-all replace")
+    }
+
+    @Test
+    fun invariantHoldsThroughDeleteAcrossParagraphs() {
+        val state = RichTextState()
+        state.setHtml("<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>")
+        state.assertVtInvariant("initial")
+
+        val text = state.annotatedString.text
+        val firstEnd = text.indexOf("paragraph") + "paragraph".length
+        val thirdStart = text.lastIndexOf("Third")
+        state.selection = TextRange(firstEnd, thirdStart)
+        val newText = text.substring(0, firstEnd) + text.substring(thirdStart)
+        state.onTextFieldValueChange(
+            TextFieldValue(text = newText, selection = TextRange(firstEnd))
+        )
+        state.assertVtInvariant("after cross-paragraph delete")
+    }
+
+    @Test
+    fun invariantHoldsThroughToggleListSpamming() {
+        val state = RichTextState()
+        state.setHtml("<p>Line 1</p><p>Line 2</p><p>Line 3</p>")
+        state.assertVtInvariant("initial")
+
+        state.selection = TextRange(0, state.annotatedString.text.length)
+        repeat(8) { i ->
+            state.toggleOrderedList()
+            state.assertVtInvariant("toggle ordered #$i")
+            state.toggleUnorderedList()
+            state.assertVtInvariant("toggle unordered #$i")
+        }
+    }
+
+    @Test
+    fun invariantHoldsThroughInlineStyleToggling() {
+        val state = RichTextState()
+        state.setText("Hello world for styling")
+        state.assertVtInvariant("initial plain")
+
+        state.selection = TextRange(0, state.annotatedString.text.length)
+        repeat(5) {
+            state.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
+            state.assertVtInvariant("toggle bold")
+            state.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold))
+            state.assertVtInvariant("untoggle bold")
+        }
+    }
+
+    @Test
+    fun invariantHoldsThroughHeadingLevelChanges() {
+        val state = RichTextState()
+        state.setText("Title text")
+        state.assertVtInvariant("plain title text")
+
+        state.selection = TextRange(0, state.annotatedString.text.length)
+        for (level in listOf(1, 2, 3, 4, 5, 6, 0, 1, 6)) {
+            state.setHeadingStyle(HeadingStyle.fromLevel(level))
+            state.assertVtInvariant("heading level=$level")
+        }
+    }
+
+    @Test
+    fun invariantHoldsThroughFormatSwitching() {
+        val state = RichTextState()
+        // Cycle through setText, setHtml, setMarkdown rapidly. Different parsers,
+        // different paragraph trees, different prefix shapes.
+        repeat(10) { i ->
+            state.setText("plain $i with extra text repeated $i $i")
+            state.assertVtInvariant("setText iter $i")
+
+            state.setHtml(
+                "<h${(i % 6) + 1}>Heading</h${(i % 6) + 1}>" +
+                    "<ol>" + (1..(i % 5 + 2)).joinToString("") { "<li>x$it</li>" } + "</ol>" +
+                    "<p>Body $i with <b>bold</b> and <i>italic</i></p>"
+            )
+            state.assertVtInvariant("setHtml iter $i")
+
+            state.setMarkdown(
+                "# Title $i\n\n" +
+                    (1..(i % 4 + 2)).joinToString("\n") { "- bullet $it" } + "\n\n" +
+                    "Body **strong** and *em* paragraph $i."
+            )
+            state.assertVtInvariant("setMarkdown iter $i")
+        }
+    }
+
+    @Test
+    fun invariantHoldsThroughUndoRedoCycles() {
+        val state = RichTextState()
+        state.setHtml("<p>Initial</p>")
+
+        for (i in 1..5) {
+            state.selection = TextRange(state.annotatedString.text.length)
+            state.simulateTyping(" step $i")
+            state.assertVtInvariant("after typing step $i")
+        }
+
+        // Undo all
+        repeat(5) { i ->
+            if (state.history.canUndo) {
+                state.history.undo()
+                state.assertVtInvariant("after undo $i")
+            }
+        }
+
+        // Redo all
+        repeat(5) { i ->
+            if (state.history.canRedo) {
+                state.history.redo()
+                state.assertVtInvariant("after redo $i")
+            }
+        }
+    }
+
+    // ====================================================================
+    // 4. Combined chaos
+    // ====================================================================
+
+    @Test
+    fun invariantHoldsThroughCombinedChaos() {
+        val state = RichTextState()
+        state.registerTrigger(Trigger(id = "mention", char = '@'))
+        state.registerTrigger(Trigger(id = "hashtag", char = '#'))
+
+        // Phase 1: build a doc through multiple format paths
+        state.setHtml(
+            "<h2>Doc</h2>" +
+                "<p>Intro with <b>bold</b> and <i>italic</i> and " +
+                "<a href=\"https://x.com\">link</a>.</p>" +
+                "<ol>" + (1..7).joinToString("") { "<li>Item $it</li>" } + "</ol>" +
+                "<ul><li>A</li><li>B</li></ul>" +
+                "<p>Outro <code>code</code></p>"
+        )
+        state.assertVtInvariant("phase 1 setHtml")
+
+        // Phase 2: cursor jumps
+        val jumpPoints = listOf(
+            0,
+            state.annotatedString.text.length / 4,
+            state.annotatedString.text.length / 2,
+            state.annotatedString.text.length * 3 / 4,
+            state.annotatedString.text.length,
+        )
+        for (p in jumpPoints) {
+            state.selection = TextRange(p)
+            state.assertVtInvariant("cursor jump $p")
+        }
+
+        // Phase 3: typing into the middle
+        val midText = state.annotatedString.text.length / 2
+        state.selection = TextRange(midText)
+        state.simulateTyping("INSERTED")
+        state.assertVtInvariant("after middle typing")
+
+        // Phase 4: multiple Enters at end pushes past 9 -> 10 list boundary
+        for (i in 1..6) {
+            state.selection = TextRange(state.annotatedString.text.length)
+            state.simulateEnter()
+            state.assertVtInvariant("phase 4 Enter $i")
+            state.simulateTyping("New $i")
+            state.assertVtInvariant("phase 4 typing $i")
+        }
+
+        // Phase 5: select-all replace
+        state.selection = TextRange(0, state.annotatedString.text.length)
+        state.onTextFieldValueChange(
+            TextFieldValue(text = "Fresh content", selection = TextRange(13))
+        )
+        state.assertVtInvariant("phase 5 select-all replace")
+
+        // Phase 6: rebuild via markdown with token spans
+        state.setMarkdown(
+            "**Notes:** [@alice](trigger:mention:u-a) on " +
+                "[#release](trigger:hashtag:r)\n\n" +
+                "1. one\n2. two\n3. three\n\n" +
+                "- bullet A\n- bullet B"
+        )
+        state.assertVtInvariant("phase 6 setMarkdown with tokens")
+
+        // Phase 7: backspace through the document
+        state.selection = TextRange(state.annotatedString.text.length)
+        repeat(15) { i ->
+            if (state.selection.min > 0) {
+                state.simulateBackspace()
+                state.assertVtInvariant("phase 7 backspace $i")
+            }
+        }
+
+        // Phase 8: rapid format switching
+        repeat(6) { i ->
+            state.setText("plain text $i")
+            state.assertVtInvariant("phase 8 setText $i")
+
+            state.setHtml("<ol><li>Only</li></ol>")
+            state.assertVtInvariant("phase 8 setHtml $i")
+
+            state.setMarkdown("# Title\n\nBody $i.")
+            state.assertVtInvariant("phase 8 setMarkdown $i")
+        }
+    }
+
+    @Test
+    fun invariantHoldsThroughManyCapturedSnapshotsInterleaved() {
+        // Capture VTs at multiple stages, mutate between captures, and verify
+        // each captured VT still produces its own paired length.
+        val state = RichTextState()
+
+        data class Capture(
+            val vt: androidx.compose.ui.text.input.VisualTransformation,
+            val length: Int,
+        )
+        val captures = mutableListOf<Capture>()
+
+        for (i in 0 until 12) {
+            state.setHtml("<p>Stage $i with extra " + "x".repeat(i * 3) + "</p>")
+            captures.add(Capture(state.visualTransformation, state.textFieldValue.text.length))
+        }
+
+        // Now invoke each captured VT with its paired-length input, verify match.
+        captures.forEachIndexed { i, capture ->
+            val input = AnnotatedString(buildString { repeat(capture.length) { append('x') } })
+            val transformed = capture.vt.filter(input)
+            assertEquals(
+                capture.length,
+                transformed.text.length,
+                "Capture #$i lost its paired length"
+            )
+        }
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateVisualTransformationRaceTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextStateVisualTransformationRaceTest.kt
@@ -290,7 +290,7 @@ class RichTextStateVisualTransformationRaceTest {
         val state = RichTextState()
         state.setHtml(
             "<p>" +
-                ("This is a long paragraph that wraps and wraps. ".repeat(40)) +
+                "This is a long paragraph that wraps and wraps. ".repeat(40) +
                 "</p>"
         )
         state.assertVtInvariant("long flowing paragraph")

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserDecodeTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/RichTextStateHtmlParserDecodeTest.kt
@@ -31,7 +31,8 @@ class RichTextStateHtmlParserDecodeTest {
 
         val parsedHtml = RichTextStateHtmlParser.decode(richTextState)
 
-        assertEquals(html, parsedHtml)
+        // "&excl;" decodes to "!", which needs no entity on re-encode.
+        assertEquals("<br><p>Hello World!</p>", parsedHtml)
     }
 
     @Test
@@ -354,18 +355,23 @@ class RichTextStateHtmlParserDecodeTest {
 
     @Test
     fun testDecodeListsWithDifferentLevels() {
+        // Nested lists are children of their parent <li> (#736).
         val expectedHtml = """
             <ol>
-                <li>F</li>
-                <ol><li>FFO</li><li>FSO</li></ol>
-                <ul>
-                    <li>FFU</li><li>FSU</li>
-                    <ul><li>FSU3</li></ul>
-                </ul>
+                <li>F
+                    <ol><li>FFO</li><li>FSO</li></ol>
+                    <ul>
+                        <li>FFU</li>
+                        <li>FSU
+                            <ul><li>FSU3</li></ul>
+                        </li>
+                    </ul>
+                </li>
             </ol>
             <ul>
-                <li>FFU</li>
-                <ol><li>FFO</li></ol>
+                <li>FFU
+                    <ol><li>FFO</li></ol>
+                </li>
             </ul>
             <p>Last</p>
         """
@@ -513,13 +519,13 @@ class RichTextStateHtmlParserDecodeTest {
 
         // Test end range
         assertEquals(
-            "<p>World&excl;</p>",
+            "<p>World!</p>",
             richTextState.toHtml(TextRange(6, 12))
         )
 
         // Test full range
         assertEquals(
-            "<p>Hello World&excl;</p>",
+            "<p>Hello World!</p>",
             richTextState.toHtml(TextRange(0, 12))
         )
 
@@ -742,4 +748,17 @@ class RichTextStateHtmlParserDecodeTest {
         val expectedHtmlPart = "<h2>Paragraph 2</h2>"
         assertTrue(html.contains(expectedHtmlPart), "Generated HTML should contain $expectedHtmlPart")
     }
+
+    @Test
+    fun testDecodeLineBreakContinuationFollowedByNestedList() {
+        // The nested list must stay inside the parent <li> even when the item's
+        // content ends with a <br> continuation (#736).
+        val html = "<ul><li>a<br>b<ul><li>c</li></ul></li></ul>"
+
+        val state = RichTextState()
+        state.setHtml(html)
+
+        assertEquals(html, state.toHtml())
+    }
+
 }

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/Issue734OrderedListStartTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/markdown/Issue734OrderedListStartTest.kt
@@ -1,0 +1,51 @@
+package com.mohamedrejeb.richeditor.parser.markdown
+
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.paragraph.type.OrderedList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Ordered-list numbering parsed from Markdown must preserve the author's numbers
+ * instead of resetting to 1, both when the list starts at a number other than 1 and
+ * when a non-list paragraph is interleaved between items (#734).
+ */
+class Issue734OrderedListStartTest {
+
+    private fun orderedListNumbers(markdown: String): List<Int> {
+        val state = RichTextState()
+        state.setMarkdown(markdown)
+        return state.richParagraphList.mapNotNull { (it.type as? OrderedList)?.number }
+    }
+
+    @Test
+    fun listStartingAtOneIsSequential() {
+        assertEquals(listOf(1, 2, 3), orderedListNumbers("1. a\n2. b\n3. c"))
+    }
+
+    @Test
+    fun listStartingAtFivePreservesStartNumber() {
+        assertEquals(listOf(5, 6), orderedListNumbers("5. five\n6. six"))
+    }
+
+    @Test
+    fun listStartingAtMultiDigitPreservesStartNumber() {
+        assertEquals(listOf(10, 11, 12), orderedListNumbers("10. ten\n11. eleven\n12. twelve"))
+    }
+
+    @Test
+    fun numberingSurvivesParagraphBetweenItems() {
+        val markdown = "1. first\n   continuation\n\n2. second\n3. third"
+        assertEquals(listOf(1, 2, 3), orderedListNumbers(markdown))
+    }
+
+    @Test
+    fun indentedItemAfterTextDoesNotCrash() {
+        // correctMarkdownText shifts node offsets relative to the raw input; the
+        // LIST_NUMBER seed must read from the corrected text or this throws.
+        val state = RichTextState()
+        state.setMarkdown("a\n  1. b")
+        assertTrue(state.annotatedString.text.contains("a"))
+    }
+}

--- a/richeditor-compose/src/desktopTest/kotlin/com/mohamedrejeb/richeditor/ui/DoubleClickWordSelectionTest.kt
+++ b/richeditor-compose/src/desktopTest/kotlin/com/mohamedrejeb/richeditor/ui/DoubleClickWordSelectionTest.kt
@@ -1,0 +1,257 @@
+package com.mohamedrejeb.richeditor.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import com.mohamedrejeb.richeditor.model.RichTextState
+import org.junit.Test
+import kotlin.test.fail
+
+/**
+ * Reproduction: double-clicking a short word in an ordered list selects the word, then
+ * the selection shifts (reported as "Three" becoming "3. Thre": pulled back over the
+ * list marker with the last letter dropped).
+ */
+@OptIn(ExperimentalTestApi::class)
+class DoubleClickWordSelectionTest {
+
+    @Test
+    fun `double click word selection in ordered list must stay on the word`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val state = RichTextState()
+            setContent {
+                BasicRichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("editor"),
+                )
+            }
+            state.setMarkdown("1. One\n2. Two\n3. Three\n4. Four\n5. Five")
+            waitForIdle()
+
+            runDoubleClickProbe(state, wordCharOffset = 1)
+        }
+
+    @Test
+    fun `double click matrix over click positions`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val state = RichTextState()
+            setContent {
+                BasicRichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("editor"),
+                )
+            }
+            state.setMarkdown("1. One\n2. Two\n3. Three\n4. Four\n5. Five")
+            waitForIdle()
+
+            // Click every character position of the word, including the last one
+            for (offset in 0 until "Three".length) {
+                runDoubleClickProbe(state, wordCharOffset = offset)
+            }
+        }
+
+    @Test
+    fun `double click with background spans still on the word`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val state = RichTextState()
+            setContent {
+                BasicRichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("editor"),
+                )
+            }
+            // A background span makes the #635 selection mask relevant, so every
+            // selection change rebuilds the annotated string mid-gesture: the one
+            // legitimate case where the rc14 rebuild path still runs
+            state.setHtml(
+                "<ol><li>One</li><li>Two</li>" +
+                    "<li><span style=\"background-color:#ffff00\">Three</span></li>" +
+                    "<li>Four</li><li>Five</li></ol>",
+            )
+            waitForIdle()
+
+            for (offset in 0 until "Three".length) {
+                runDoubleClickProbe(state, wordCharOffset = offset)
+            }
+        }
+
+    @Test
+    fun `double click after building the list by typing`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val state = RichTextState()
+            setContent {
+                BasicRichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("editor"),
+                )
+            }
+            waitForIdle()
+
+            // Build the list the way a user does: type "1. " (auto-detected), the
+            // item text, then Enter for each following item
+            fun type(textToAdd: String) {
+                for (ch in textToAdd) {
+                    val current = state.textFieldValue.text
+                    val caret = state.selection.min
+                    state.onTextFieldValueChange(
+                        androidx.compose.ui.text.input.TextFieldValue(
+                            text = current.substring(0, caret) + ch + current.substring(caret),
+                            selection = androidx.compose.ui.text.TextRange(caret + 1),
+                        ),
+                    )
+                }
+            }
+            type("1. One\nTwo\nThree\nFour\nFive")
+            waitForIdle()
+
+            for (offset in 0 until "Three".length) {
+                runDoubleClickProbe(state, wordCharOffset = offset)
+            }
+        }
+
+    @Test
+    fun `double click in material editor with padding`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val state = RichTextState()
+            setContent {
+                com.mohamedrejeb.richeditor.ui.material3.RichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("editor"),
+                )
+            }
+            state.setMarkdown("1. One\n2. Two\n3. Three\n4. Four\n5. Five")
+            waitForIdle()
+
+            for (offset in 0 until "Three".length) {
+                runDoubleClickProbe(state, wordCharOffset = offset)
+            }
+        }
+
+    @Test
+    fun `double click with realistic timing and jitter`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val state = RichTextState()
+            setContent {
+                BasicRichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("editor"),
+                )
+            }
+            state.setMarkdown("1. One\n2. Two\n3. Three\n4. Four\n5. Five")
+            waitForIdle()
+
+            val text = state.textFieldValue.text
+            val wordStart = text.indexOf("Three")
+            val wordEnd = wordStart + "Three".length
+            val layout = checkNotNull(state.textLayoutResult)
+            val node = onNodeWithTag("editor").fetchSemanticsNode()
+            val origin = state.textFieldWindowPosition - node.positionInRoot
+            val clickAt = origin + layout.getBoundingBox(wordStart + 2).center
+
+            val observations = mutableListOf<String>()
+            fun snapshot(label: String) {
+                val sel = state.selection
+                observations += "$label: $sel \"${
+                    state.textFieldValue.text.substring(sel.min, sel.max)
+                }\""
+            }
+
+            // Real double click: press/release, ~180ms, press, 1px jitter, release
+            onNodeWithTag("editor").performMouseInput {
+                moveTo(clickAt)
+                press()
+                advanceEventTime(40)
+                release()
+                advanceEventTime(180)
+                press()
+                advanceEventTime(20)
+                moveBy(androidx.compose.ui.geometry.Offset(1f, 0f))
+                advanceEventTime(30)
+                release()
+            }
+            waitForIdle()
+            snapshot("after gesture")
+            repeat(8) {
+                mainClock.advanceTimeBy(50)
+                waitForIdle()
+                snapshot("after +${(it + 1) * 50}ms")
+            }
+
+            val sel = state.selection
+            if (sel.min != wordStart || sel.max != wordEnd) {
+                fail(
+                    buildString {
+                        appendLine("Selection drifted with realistic double click.")
+                        appendLine("expected ($wordStart, $wordEnd), text=\"$text\"")
+                        observations.forEach { appendLine("  $it") }
+                    },
+                )
+            }
+        }
+
+    private fun ComposeUiTest.runDoubleClickProbe(
+        state: RichTextState,
+        wordCharOffset: Int,
+    ) {
+        val text = state.textFieldValue.text
+        val wordStart = text.indexOf("Three")
+        val wordEnd = wordStart + "Three".length
+
+        val layout = checkNotNull(state.textLayoutResult) { "layout not ready" }
+        // Translate from text-layout space to node space (the Material decoration
+        // offsets the inner text field by its content padding)
+        val node = onNodeWithTag("editor").fetchSemanticsNode()
+        val textOriginInNode = state.textFieldWindowPosition - node.positionInRoot
+        val clickAt = textOriginInNode + layout.getBoundingBox(wordStart + wordCharOffset).center
+
+        val observations = mutableListOf<String>()
+
+        fun snapshot(label: String) {
+            val sel = state.selection
+            observations += "$label: $sel \"${
+                state.textFieldValue.text.substring(sel.min, sel.max)
+            }\""
+        }
+
+        onNodeWithTag("editor").performMouseInput {
+            doubleClick(clickAt)
+        }
+        waitForIdle()
+        snapshot("right after double click")
+
+        repeat(8) {
+            mainClock.advanceTimeBy(50)
+            waitForIdle()
+            snapshot("after +${(it + 1) * 50}ms")
+        }
+
+        val finalSel = state.selection
+        if (finalSel.min != wordStart || finalSel.max != wordEnd) {
+            fail(
+                buildString {
+                    appendLine("Selection drifted off the double-clicked word (clicked char $wordCharOffset).")
+                    appendLine("expected ($wordStart, $wordEnd), text=\"$text\"")
+                    observations.forEach { appendLine("  $it") }
+                },
+            )
+        }
+    }
+}

--- a/richeditor-compose/src/desktopTest/kotlin/com/mohamedrejeb/richeditor/ui/Issue717LazyColumnFlingScrollTest.kt
+++ b/richeditor-compose/src/desktopTest/kotlin/com/mohamedrejeb/richeditor/ui/Issue717LazyColumnFlingScrollTest.kt
@@ -1,0 +1,315 @@
+package com.mohamedrejeb.richeditor.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.richeditor.model.RichTextState
+import org.junit.Test
+import kotlin.test.fail
+
+/**
+ * Guard rails for issue #717 (OffsetMapping out-of-bounds crash during LazyColumn
+ * scroll/fling): `OffsetMapping.Identity` is only valid while
+ * `annotatedString.text.length == textFieldValue.text.length`, so each test drives
+ * scroll churn over editors and asserts that invariant at every layout pass. The
+ * desktop patterns do not reproduce the original Android crash; they catch the
+ * model-level desync if it ever manifests.
+ */
+class Issue717LazyColumnFlingScrollTest {
+
+    /** Mixed paragraph types, ~168 visible chars (first variant in the report). */
+    private fun shortRichHtml(seed: Int): String = """
+        <h2>Section $seed</h2>
+        <p>Intro paragraph with <b>bold</b> and <i>italic</i> and <u>underline</u> text.</p>
+        <ol>
+          <li>First numbered item</li>
+          <li>Second numbered item</li>
+          <li>Third numbered item</li>
+        </ol>
+    """.trimIndent()
+
+    /** ~460 rendered chars (second variant in the report). */
+    private fun longRichHtml(seed: Int): String = """
+        <h2>Document #$seed</h2>
+        <p>This editor has a moderately long mixed paragraph with several inline
+        spans like <b>bold</b>, <i>italic</i>, <u>underline</u>, and
+        <code>inline code</code> embedded in regular prose so paragraph lengths
+        and list prefix widths exercise the offset-mapping validation path.</p>
+        <ol>
+          <li>Numbered item one with extra trailing words.</li>
+          <li>Numbered item two also with trailing words.</li>
+          <li>Item three to push past the 99/100 boundary in some seeds.</li>
+        </ol>
+        <ul>
+          <li>Bullet alpha</li>
+          <li>Bullet beta</li>
+        </ul>
+        <p>Closing paragraph with a final note.</p>
+    """.trimIndent()
+
+    private fun RichTextState.assertOffsetMappingInvariant(label: String) {
+        val asLen = annotatedString.text.length
+        val tfvLen = textFieldValue.text.length
+        if (asLen != tfvLen) {
+            fail(
+                "Offset mapping invariant violated $label: " +
+                    "annotatedString.length=$asLen, textFieldValue.text.length=$tfvLen " +
+                    "(diff=${tfvLen - asLen}). OffsetMapping.Identity will throw."
+            )
+        }
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `scroll through LazyColumn of BasicRichTextEditor does not crash with short content`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val editorCount = 12
+            val states = List(editorCount) { i ->
+                RichTextState().apply { setHtml(shortRichHtml(i)) }
+            }
+
+            setContent {
+                val listState = rememberLazyListState()
+
+                LaunchedEffect(Unit) {
+                    repeat(6) {
+                        listState.scrollToItem(editorCount - 1)
+                        listState.scrollToItem(0)
+                        listState.scrollToItem(editorCount / 2)
+                    }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(states) { state ->
+                        BasicRichTextEditor(
+                            state = state,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            onTextLayout = {
+                                state.assertOffsetMappingInvariant("during onTextLayout")
+                            },
+                        )
+                    }
+                }
+            }
+
+            waitForIdle()
+
+            states.forEachIndexed { i, state ->
+                state.assertOffsetMappingInvariant("after scroll, editor $i")
+            }
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `scroll through LazyColumn of BasicRichTextEditor does not crash with long content`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val editorCount = 8
+            val states = List(editorCount) { i ->
+                RichTextState().apply { setHtml(longRichHtml(i)) }
+            }
+
+            setContent {
+                val listState = rememberLazyListState()
+
+                LaunchedEffect(Unit) {
+                    repeat(8) { iter ->
+                        listState.scrollToItem(editorCount - 1)
+                        listState.scrollToItem(0)
+                        listState.scrollToItem(iter % editorCount)
+                    }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(states) { state ->
+                        BasicRichTextEditor(
+                            state = state,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            onTextLayout = {
+                                state.assertOffsetMappingInvariant("during onTextLayout (long)")
+                            },
+                        )
+                    }
+                }
+            }
+
+            waitForIdle()
+
+            states.forEachIndexed { i, state ->
+                state.assertOffsetMappingInvariant("after scroll, editor $i")
+            }
+        }
+
+    /**
+     * `dispatchRawDelta` exercises the same measure path as a real fling
+     * without animation latency.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `dispatchRawDelta fling through rich editors does not crash`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val editorCount = 10
+            val states = List(editorCount) { i ->
+                RichTextState().apply { setHtml(longRichHtml(i)) }
+            }
+
+            setContent {
+                val listState = rememberLazyListState()
+
+                LaunchedEffect(Unit) {
+                    val flingProfile = listOf(
+                        80f, 160f, 240f, 320f, 280f, 220f, 160f, 100f, 60f, 30f,
+                        -30f, -60f, -100f, -160f, -220f, -280f, -320f, -240f, -160f, -80f,
+                    )
+                    repeat(4) {
+                        flingProfile.forEach { delta ->
+                            listState.dispatchRawDelta(delta)
+                        }
+                    }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(states) { state ->
+                        BasicRichTextEditor(
+                            state = state,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            onTextLayout = {
+                                state.assertOffsetMappingInvariant("during dispatchRawDelta")
+                            },
+                        )
+                    }
+                }
+            }
+
+            waitForIdle()
+
+            states.forEachIndexed { i, state ->
+                state.assertOffsetMappingInvariant("after fling, editor $i")
+            }
+        }
+
+    /**
+     * Items leaving and re-entering composition re-run `setHtml`, which recomputes
+     * both `annotatedString` and `textFieldValue` during scroll churn.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `LazyColumn with re-mounted RichTextState items survives scroll churn`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val editorCount = 12
+
+            setContent {
+                val listState = rememberLazyListState()
+
+                LaunchedEffect(Unit) {
+                    repeat(5) {
+                        listState.scrollToItem(editorCount - 1)
+                        listState.scrollToItem(0)
+                    }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(
+                        count = editorCount,
+                        key = { it },
+                    ) { index ->
+                        val state = remember(index) {
+                            RichTextState().apply { setHtml(longRichHtml(index)) }
+                        }
+                        BasicRichTextEditor(
+                            state = state,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            onTextLayout = {
+                                state.assertOffsetMappingInvariant("during re-mount churn")
+                            },
+                        )
+                    }
+                }
+            }
+
+            waitForIdle()
+        }
+
+    /**
+     * Intermixes content mutations with scrolling so a scroll-driven measure pass can
+     * land between the `annotatedString` and `textFieldValue` writes.
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `mutate content while scrolling does not crash and keeps invariant`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            val editorCount = 8
+            val states = List(editorCount) { i ->
+                RichTextState().apply { setHtml(shortRichHtml(i)) }
+            }
+
+            setContent {
+                val listState = rememberLazyListState()
+
+                LaunchedEffect(Unit) {
+                    repeat(4) { iter ->
+                        // Mutate state of every editor before each scroll pass.
+                        states.forEachIndexed { i, state ->
+                            state.setHtml(
+                                if ((iter + i) % 2 == 0) shortRichHtml(i) else longRichHtml(i)
+                            )
+                        }
+                        listState.scrollToItem(editorCount - 1)
+                        listState.scrollToItem(0)
+                        listState.scrollToItem(editorCount / 2)
+                    }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(states) { state ->
+                        BasicRichTextEditor(
+                            state = state,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            onTextLayout = {
+                                state.assertOffsetMappingInvariant("during scroll+mutate")
+                            },
+                        )
+                    }
+                }
+            }
+
+            waitForIdle()
+
+            states.forEachIndexed { i, state ->
+                state.assertOffsetMappingInvariant("after scroll+mutate, editor $i")
+            }
+        }
+}

--- a/richeditor-compose/src/desktopTest/kotlin/com/mohamedrejeb/richeditor/ui/Issue730LongPressSelectionTest.kt
+++ b/richeditor-compose/src/desktopTest/kotlin/com/mohamedrejeb/richeditor/ui/Issue730LongPressSelectionTest.kt
@@ -1,0 +1,249 @@
+package com.mohamedrejeb.richeditor.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.mohamedrejeb.richeditor.model.RichTextState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/**
+ * Gesture-level mimics for #730 (long press selection and select-all) and #731
+ * (selection handle drag). Every press registers the press position for 300ms, during
+ * which pure selection changes route through adjustSelection; the platform delivers
+ * word selection, handle drags and select-all as plain onTextFieldValueChange calls,
+ * and these tests mimic that sequence.
+ */
+@OptIn(ExperimentalTestApi::class)
+class Issue730LongPressSelectionTest {
+
+    /**
+     * The press is registered but no layout exists yet (first frames, or editor
+     * recycled into a lazy list): the platform's word selection must still be applied.
+     */
+    @Test
+    fun `word selection arriving while press is registered without layout must not be dropped`() =
+        runBlocking {
+            val state = RichTextState()
+            state.setText("alpha beta gamma")
+            val text = state.textFieldValue.text
+
+            // Mimic the press registration the editor performs on PressInteraction.Press
+            val pressJob = launch(Dispatchers.Default) {
+                state.adjustSelectionAndRegisterPressPosition(Offset(12f, 8f))
+            }
+            delay(80) // inside the 300ms press window
+
+            // Platform long-press: select the word "beta"
+            state.onTextFieldValueChange(TextFieldValue(text, TextRange(6, 10)))
+            val applied = state.selection
+
+            pressJob.cancel()
+
+            assertEquals(
+                TextRange(6, 10),
+                applied,
+                "The word selection was dropped because a press was registered and " +
+                    "textLayoutResult was null (#730)",
+            )
+        }
+
+    /**
+     * Full gesture mimic with a real composed editor (layout available):
+     * press, long-press word selection inside the 300ms window, drag-handle extensions,
+     * a second press, then select-all. Every selection the platform sets must be honored.
+     */
+    @Test
+    fun `mimicked long press word selection then drag then select all with real layout`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            mainClock.autoAdvance = false
+            val state = RichTextState()
+            lateinit var scope: CoroutineScope
+            setContent {
+                scope = rememberCoroutineScope()
+                BasicRichTextEditor(
+                    state = state,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            mainClock.advanceTimeBy(64)
+            state.setText("alpha beta gamma\ndelta epsilon zeta\nlast line words")
+            mainClock.advanceTimeBy(64)
+
+            val text = state.textFieldValue.text
+            val issues = mutableListOf<String>()
+
+            fun expectSelection(label: String, expected: TextRange) {
+                if (state.selection != expected) {
+                    issues += "$label: expected $expected, actual ${state.selection}"
+                }
+            }
+
+            // Press at the start of the field, then the platform's long-press word
+            // selection arrives while the press is still registered (within 300ms)
+            scope.launch { state.adjustSelectionAndRegisterPressPosition(Offset(8f, 8f)) }
+            mainClock.advanceTimeBy(48)
+            state.onTextFieldValueChange(TextFieldValue(text, TextRange(0, 5)))
+            mainClock.advanceTimeBy(16)
+            expectSelection("word selection within press window", TextRange(0, 5))
+
+            // Drag the end handle: successive extensions while the window expires
+            listOf(10, 16, 22).forEach { end ->
+                state.onTextFieldValueChange(TextFieldValue(state.textFieldValue.text, TextRange(0, end)))
+                mainClock.advanceTimeBy(96)
+                expectSelection("drag extension to $end", TextRange(0, end))
+            }
+
+            // Let the press window fully expire, then a long-press on the second line
+            // arrives after the window (real Android long-press timeout > 300ms)
+            mainClock.advanceTimeBy(400)
+            scope.launch { state.adjustSelectionAndRegisterPressPosition(Offset(60f, 30f)) }
+            mainClock.advanceTimeBy(350)
+            state.onTextFieldValueChange(TextFieldValue(state.textFieldValue.text, TextRange(17, 22)))
+            mainClock.advanceTimeBy(16)
+            expectSelection("word selection after press window expired", TextRange(17, 22))
+
+            // Select all from the toolbar (no press on the field)
+            val len = state.textFieldValue.text.length
+            state.onTextFieldValueChange(TextFieldValue(state.textFieldValue.text, TextRange(0, len)))
+            mainClock.advanceTimeBy(16)
+            expectSelection("select all", TextRange(0, len))
+
+            if (issues.isNotEmpty()) {
+                fail("Selection gestures were not honored:\n" + issues.joinToString("\n"))
+            }
+        }
+
+    /**
+     * Seeded fuzz over the gesture surface with a real layout: random presses (with the
+     * 300ms window sometimes active, sometimes expired), random word/range selections,
+     * drag extensions and occasional typing. Oracles: no exception, the selection the
+     * platform set is honored for non-collapsed selections, and the annotated string
+     * stays in sync with the text field value.
+     */
+    @Test
+    fun `selection gesture fuzz with real layout`() =
+        runDesktopComposeUiTest(width = 480, height = 360) {
+            mainClock.autoAdvance = false
+            val state = RichTextState()
+            lateinit var scope: CoroutineScope
+            setContent {
+                scope = rememberCoroutineScope()
+                BasicRichTextEditor(
+                    state = state,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            mainClock.advanceTimeBy(64)
+
+            for (seed in 0 until 30) {
+                val random = Random(seed)
+                val opLog = mutableListOf<String>()
+                state.setMarkdown(
+                    when (seed % 3) {
+                        0 -> "alpha beta gamma\n\ndelta epsilon zeta\n\nlast line words"
+                        1 -> "- item one\n- item two\n- item three"
+                        else -> "1. first entry\n2. second entry\n3. third entry"
+                    },
+                )
+                mainClock.advanceTimeBy(64)
+
+                fun finding(message: String): Nothing =
+                    fail(
+                        buildString {
+                            appendLine("Selection gesture fuzz finding, seed=$seed")
+                            appendLine(message)
+                            opLog.forEach { appendLine("  $it") }
+                        },
+                    )
+
+                repeat(12) {
+                    val text = state.textFieldValue.text
+                    try {
+                        when (random.nextInt(10)) {
+                            in 0..2 -> {
+                                val x = random.nextInt(200).toFloat()
+                                val y = random.nextInt(80).toFloat()
+                                opLog += "press($x,$y)"
+                                scope.launch {
+                                    state.adjustSelectionAndRegisterPressPosition(Offset(x, y))
+                                }
+                                mainClock.advanceTimeBy(random.nextInt(16, 64).toLong())
+                            }
+
+                            in 3..5 -> {
+                                if (text.isNotEmpty()) {
+                                    val a = random.nextInt(text.length)
+                                    val b = (a + 1 + random.nextInt(text.length - a))
+                                        .coerceAtMost(text.length)
+                                    opLog += "select[$a,$b]"
+                                    state.onTextFieldValueChange(TextFieldValue(text, TextRange(a, b)))
+                                    mainClock.advanceTimeBy(16)
+                                    if (state.selection != TextRange(a, b)) {
+                                        finding(
+                                            "non-collapsed selection not honored: " +
+                                                "requested [$a,$b], actual ${state.selection}",
+                                        )
+                                    }
+                                }
+                            }
+
+                            in 6..7 -> {
+                                val pos = random.nextInt(text.length + 1)
+                                opLog += "caret@$pos"
+                                state.onTextFieldValueChange(TextFieldValue(text, TextRange(pos)))
+                                mainClock.advanceTimeBy(16)
+                            }
+
+                            8 -> {
+                                val caret = state.selection.min.coerceIn(0, text.length)
+                                val ch = 'a' + random.nextInt(26)
+                                opLog += "type '$ch'@$caret"
+                                state.onTextFieldValueChange(
+                                    TextFieldValue(
+                                        text.substring(0, caret) + ch + text.substring(caret),
+                                        TextRange(caret + 1),
+                                    ),
+                                )
+                                mainClock.advanceTimeBy(16)
+                            }
+
+                            else -> {
+                                opLog += "expire press window"
+                                mainClock.advanceTimeBy(400)
+                            }
+                        }
+                    } catch (t: Throwable) {
+                        if (t is AssertionError) throw t
+                        finding("CRASH: ${t.stackTraceToString()}")
+                    }
+
+                    val tfv = state.textFieldValue
+                    if (tfv.text != state.annotatedString.text) {
+                        finding(
+                            "annotatedString/textFieldValue mismatch: " +
+                                "tfv=\"${tfv.text}\" annotated=\"${state.annotatedString.text}\"",
+                        )
+                    }
+                    if (tfv.selection.max > tfv.text.length || tfv.selection.min < 0) {
+                        finding("selection out of bounds: ${tfv.selection} len=${tfv.text.length}")
+                    }
+                }
+
+                // Let pending press windows expire between scenarios
+                mainClock.advanceTimeBy(400)
+            }
+        }
+}


### PR DESCRIPTION
## Summary

Stabilization pass over the v1 edit pipeline, driven by fuzzing (three harnesses, ~2000 scenarios) plus an adversarial multi-agent review of the diff.

**Edit pipeline (model)**
- Replace the IME-revert guess in `onTextFieldValueChange` with diff-based edit application (longest common prefix/suffix): batched IME edits (delete + newline, autocorrect behind the caret, same-length replacements) now apply where they actually happened. Fixes the `StringIndexOutOfBoundsException` crash family (#716) and several silent corruption paths.
- The span tree is now the source of truth: the field text is re-derived from the tree after each mutating edit, so tree/text desyncs can no longer accumulate into crashes.
- `visualTransformation` snapshots the annotated string by value, and mid-selection rebuilds only happen when a span carries a background color. Fixes the `OffsetMapping` crash during scroll/fling (#717) and restores Android long-press / handle-drag selection (#730, #731).
- Platform selection is applied even when layout is not ready yet (#730).
- History: `setText` clears undo history like `setHtml`/`setMarkdown`; same-length replacements are recorded; `OrderedList.copy` preserves `startFrom` across undo snapshots.

**Parsers**
- HTML: minimal entity escaping (only `&`, `<`, `>`), so "fj" no longer exports as `&fjlig;` (#735); space runs survive round trips via `&#32;` (#726, hex/padded forms recognized on import); nested lists export inside their parent `<li>` (#736); empty list items survive reload; `<br>` continuations stay inside their open item.
- Markdown: ordered-list numbering is preserved via `startFrom` seeded from the source number, including across interleaved paragraphs (#734).

**Known limitations** (documented in code comments): a character committed exactly at a paragraph-boundary position is rewritten to the separator space; a newline inserted before the old caret in a multi-paragraph document is stored but not split into a paragraph; list level jumps > 1 still export as bare nested lists (deliberate round-trip tradeoff).

## Testing

New: deterministic issue pins (`Issue716StringIndexFuzzTest`, `Issue730SelectionRegressionTest`, `Issue730LongPressSelectionTest`, `Issue717LazyColumnFlingScrollTest`, `Issue734OrderedListStartTest`), fuzz harnesses (`RichTextEditCorruptionFuzzTest`, `RichTextHtmlRoundTripFuzzTest`), `RichTextStateCorruptionCollectionTest`, `RichTextStateVisualTransformationRaceTest`, `DoubleClickWordSelectionTest`.

- [x] `:richeditor-compose:desktopTest` (722 tests, 0 failures)
- [x] `:richeditor-compose:compileTestKotlinJs`
- [x] `apiCheck`
- [x] `allTests` on CI (iOS / Wasm)
- [x] Manual Android device pass: long-press selection, handle drag, list typing on Samsung keyboard

Fixes #716, #717, #726, #730, #731, #734, #735, #736