### PR TITLE
fix: combine nested text decorations instead of replacing it (#741, #740).

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpan.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichSpan.kt
@@ -56,7 +56,7 @@ internal class RichSpan(
         var parent = this.parent
 
         while (parent != null) {
-            spanStyle = parent.spanStyle.merge(spanStyle)
+            spanStyle = parent.spanStyle.customMerge(spanStyle)
             parent = parent.parent
         }
 

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/utils/AnnotatedStringExt.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/utils/AnnotatedStringExt.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachIndexed
@@ -95,7 +96,7 @@ internal fun AnnotatedString.Builder.appendRichSpan(
             else
                 parent.richSpanStyle
 
-        parent.spanStyle = parent.spanStyle.merge(firstChild.spanStyle)
+        parent.spanStyle = parent.spanStyle.customMerge(firstChild.spanStyle)
         parent.richSpanStyle = richSpanStyle
         parent.text = firstChild.text
         parent.textRange = firstChild.textRange
@@ -121,7 +122,7 @@ internal fun AnnotatedString.Builder.append(
 ): Int {
     var index = startIndex
 
-    withStyle(richSpan.spanStyle.merge(resolveRichSpanStyleStyle(state, richSpan.richSpanStyle))) {
+    withStyle(effectiveSpanStyle(state, richSpan)) {
         if (richSpan.richSpanStyle is RichSpanStyle.Image) {
             // Image owns a single placeholder char in the raw text;
             // appendCustomContent (via appendInlineContent) emits that
@@ -235,7 +236,7 @@ internal fun AnnotatedString.Builder.append(
 ): Int {
     var index = startIndex
 
-    withStyle(richSpan.spanStyle.merge(resolveRichSpanStyleStyle(state, richSpan.richSpanStyle))) {
+    withStyle(effectiveSpanStyle(state, richSpan)) {
         richSpan.textRange = TextRange(index, index + richSpan.text.length)
 
         // Image owns a single placeholder char in the raw text;
@@ -274,6 +275,24 @@ internal fun AnnotatedString.Builder.append(
  * for [RichSpanStyle.Token] spans when the trigger is known. Falls back to the style
  * encoded on the [RichSpanStyle] itself (which, for Token, is a neutral default).
  */
+
+/**
+ * The style pushed for a span: its own style merged with its [RichSpanStyle]'s, with
+ * the textDecoration combined with the inherited one. Builder nesting would let this
+ * span's decoration replace the parent's, dropping underline or strikethrough when
+ * the two are nested.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+private fun effectiveSpanStyle(state: RichTextState, richSpan: RichSpan): SpanStyle {
+    val spanStyle = richSpan.spanStyle.merge(resolveRichSpanStyleStyle(state, richSpan.richSpanStyle))
+    val inheritedDecoration = richSpan.parent?.fullSpanStyle?.textDecoration ?: return spanStyle
+    val ownDecoration = spanStyle.textDecoration ?: return spanStyle
+    if (inheritedDecoration == ownDecoration) return spanStyle
+    return spanStyle.copy(
+        textDecoration = TextDecoration.combine(listOf(inheritedDecoration, ownDecoration)),
+    )
+}
+
 @OptIn(ExperimentalRichTextApi::class)
 private fun resolveRichSpanStyleStyle(
     state: RichTextState,

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue741NestedDecorationTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue741NestedDecorationTest.kt
@@ -1,0 +1,86 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.style.TextDecoration
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression pins for #741 (and the styling half of #740): nested underline and
+ * strikethrough must render together. The child's textDecoration used to replace the
+ * parent's, both in [RichSpan.fullSpanStyle] (plain merge) and in the annotated
+ * string builder (style nesting), while the toggle path already combined them via
+ * customMerge.
+ */
+class Issue741NestedDecorationTest {
+
+    private fun collectSpans(state: RichTextState): List<RichSpan> {
+        val result = mutableListOf<RichSpan>()
+        fun walk(span: RichSpan) {
+            result += span
+            span.children.forEach(::walk)
+        }
+        state.richParagraphList.forEach { p -> p.children.forEach(::walk) }
+        return result
+    }
+
+    private fun assertBothDecorations(state: RichTextState, context: String) {
+        // Model level
+        val span = collectSpans(state).first { it.text.contains("sample") }
+        val modelDeco = span.fullSpanStyle.textDecoration
+        assertTrue(
+            modelDeco != null &&
+                modelDeco.contains(TextDecoration.Underline) &&
+                modelDeco.contains(TextDecoration.LineThrough),
+            "$context: fullSpanStyle.textDecoration=$modelDeco",
+        )
+
+        // Render level: the innermost annotated-string style covering the text must
+        // carry both decorations (nesting would otherwise drop the outer one)
+        val start = state.annotatedString.text.indexOf("sample")
+        val styles = state.annotatedString.spanStyles.filter {
+            start >= it.start && start < it.end && it.item.textDecoration != null
+        }
+        val renderDeco = styles.lastOrNull()?.item?.textDecoration
+        assertTrue(
+            renderDeco != null &&
+                renderDeco.contains(TextDecoration.Underline) &&
+                renderDeco.contains(TextDecoration.LineThrough),
+            "$context: rendered textDecoration=$renderDeco",
+        )
+    }
+
+    @Test
+    fun `html u outer s inner renders both`() {
+        val state = RichTextState()
+        state.setHtml("<p><u><s>sample</s></u></p>")
+        assertBothDecorations(state, "u outer")
+    }
+
+    @Test
+    fun `html s outer u inner renders both`() {
+        val state = RichTextState()
+        state.setHtml("<p><s><u>sample</u></s></p>")
+        assertBothDecorations(state, "s outer")
+    }
+
+    @Test
+    fun `toggling both decorations keeps both`() {
+        val state = RichTextState()
+        state.setText("sample text")
+        state.selection = TextRange(0, 6)
+        state.toggleSpanStyle(SpanStyle(textDecoration = TextDecoration.Underline))
+        state.toggleSpanStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
+        assertBothDecorations(state, "toggle path")
+    }
+
+    @Test
+    fun `combined decorations survive html round trip`() {
+        val state = RichTextState()
+        state.setHtml("<p><u><s>sample</s></u></p>")
+        val reimported = RichTextState()
+        reimported.setHtml(state.toHtml())
+        assertBothDecorations(reimported, "round trip")
+    }
+}


### PR DESCRIPTION
Closes: #740 #741 