### PR TITLE
fix: resolve relative text-indent units to sp on HTML import (#724)

### DIFF
--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/CssEncoder.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/parser/html/CssEncoder.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.*
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
@@ -432,8 +433,12 @@ internal object CssEncoder {
         if (cssTextIndent.isBlank()) return null
 
         val textUnit = parseCssTextSize(cssTextIndent)
-        return if (textUnit.isSpecified) TextIndent(textUnit, textUnit)
-            else null
+        if (!textUnit.isSpecified) return null
+
+        val spUnit =
+            if (textUnit.type == TextUnitType.Em) (textUnit.value * 16).sp
+            else textUnit
+        return TextIndent(spUnit, spUnit)
     }
 
     /**

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue762ListLevelRenumberTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/Issue762ListLevelRenumberTest.kt
@@ -1,0 +1,64 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.mohamedrejeb.richeditor.paragraph.type.OrderedList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Regression pins for #762: demoting a nested ordered-list item back to level 1,
+ * whether via backspace on its marker or via decreaseListLevel, must renumber it to
+ * continue the outer list's count. Broken in rc14, fixed by the renumbering rework.
+ */
+class Issue762ListLevelRenumberTest {
+
+    // #762: demote-by-backspace should renumber like decreaseListLevel does
+    @Test
+    fun `demoting last nested item via backspace renumbers it at the new level`() {
+        val state = RichTextState()
+        state.setMarkdown("1. hello\n    1. hi\n    2. how\n    3. are\n    4. you")
+        val text = state.textFieldValue.text
+        val youIndex = text.indexOf("you")
+        state.selection = TextRange(youIndex)
+
+        // Backspace: removes the char just before "you" (inside the "4. " marker)
+        state.onTextFieldValueChange(
+            TextFieldValue(
+                text = text.substring(0, youIndex - 1) + text.substring(youIndex),
+                selection = TextRange(youIndex - 1),
+            )
+        )
+
+        val lastType = state.richParagraphList.last().type
+        assertIs<OrderedList>(lastType, "item should stay an ordered list item")
+        assertEquals(1, lastType.level, "backspace on the marker should demote to level 1")
+        assertEquals(
+            2,
+            lastType.number,
+            "#762: demoted item should continue level-1 numbering (hello=1, you=2). " +
+                "text=\"${state.annotatedString.text}\"",
+        )
+    }
+
+    // #762 control: the shift+tab path reportedly works
+    @Test
+    fun `demoting last nested item via decreaseListLevel renumbers it`() {
+        val state = RichTextState()
+        state.setMarkdown("1. hello\n    1. hi\n    2. how\n    3. are\n    4. you")
+        val text = state.textFieldValue.text
+        state.selection = TextRange(text.indexOf("you") + 1)
+        state.decreaseListLevel()
+
+        val lastType = state.richParagraphList.last().type
+        assertIs<OrderedList>(lastType)
+        assertEquals(1, lastType.level)
+        assertEquals(
+            2,
+            lastType.number,
+            "decreaseListLevel: demoted item should continue level-1 numbering. " +
+                "text=\"${state.annotatedString.text}\"",
+        )
+    }
+}

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/CssEncoderTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/CssEncoderTest.kt
@@ -369,12 +369,14 @@ class CssEncoderTest {
             null,
             CssEncoder.parseCssTextIndent(textIndent1),
         )
+        // Relative units resolve to Sp against the 16px default font size;
+        // Em TextIndent crashes Compose layout ("Only Sp can convert to Px", #724).
         assertEquals(
-            TextIndent(1.5.em, 1.5.em),
+            TextIndent(24.sp, 24.sp),
             CssEncoder.parseCssTextIndent(textIndent2),
         )
         assertEquals(
-            TextIndent(3.em, 3.em),
+            TextIndent(48.sp, 48.sp),
             CssEncoder.parseCssTextIndent(textIndent3),
         )
         assertEquals(

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/Issue724TextIndentUnitsTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/parser/html/Issue724TextIndentUnitsTest.kt
@@ -1,0 +1,30 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.unit.TextUnitType
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression pin for #724: text-indent values in em/rem/% used to reach
+ * [androidx.compose.ui.text.style.TextIndent] as Em units, which crashes Compose's
+ * layout pass with "Only Sp can convert to Px". Relative units are resolved against
+ * the 16px default font size on import.
+ */
+class Issue724TextIndentUnitsTest {
+
+    @Test
+    fun `text-indent in em rem or percent must not produce Em text indent`() {
+        val offenders = mutableListOf<String>()
+        for (css in listOf("2em", "1.5rem", "50%", "24px", "12pt")) {
+            val state = RichTextState()
+            state.setHtml("""<p style="text-indent: $css">Hello</p>""")
+            val indent = state.richParagraphList.first().paragraphStyle.textIndent
+            if (indent != null &&
+                (indent.firstLine.type == TextUnitType.Em || indent.restLine.type == TextUnitType.Em)
+            ) {
+                offenders += "$css -> $indent"
+            }
+        }
+        assertTrue(offenders.isEmpty(), "Em TextIndent reached the paragraph style:\n" + offenders.joinToString("\n"))
+    }
+}


### PR DESCRIPTION
Em TextIndent crashes Compose layout with "Only Sp can convert to Px". Also pins the #762 list renumbering behavior fixed by the edit pipeline rework.