### PR TITLE
feat: inherit the replaced selection's style when typing or pasting over it

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Deploy snapshot
         env:
-          VERSION: 1.0.0-SNAPSHOT
+          VERSION: 1.1.0-SNAPSHOT
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}

--- a/docs/rich_text_state.md
+++ b/docs/rich_text_state.md
@@ -81,6 +81,10 @@ richTextState.selection = TextRange(0, richTextState.annotatedString.text.length
 richTextState.selection = TextRange(richTextState.annotatedString.text.length)
 ```
 
+### Replacing a selection
+
+Typing, an IME commit, or a plain-text paste over a non-collapsed selection styles the inserted text from the replaced range's start (the platform typing-attributes convention), not from the character before the caret. The restyle is part of the same edit, so undo treats the replacement as a single entry. Rich span styles are inherited only when they accept edge text and are not atomic, so replacing a whole link or image never linkifies or atomizes the typed text.
+
 ### Text Modification
 
 The `RichTextState` provides methods to modify text while preserving styles:

--- a/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
+++ b/richeditor-compose/src/commonMain/kotlin/com/mohamedrejeb/richeditor/model/RichTextState.kt
@@ -2073,6 +2073,9 @@ public class RichTextState internal constructor(
         val pendingHtml = pendingClipboardHtml.takeIf { config.richClipboardEnabled }
         val isPaste = pendingHtml != null &&
                 isPasteTextChange(textFieldValue, newTextFieldValue, pendingClipboardPlainText)
+        val replacedStyles =
+            if (isPaste) null
+            else captureReplacedSelectionStyles(textFieldValue, newTextFieldValue)
         val trigger: CommitTrigger? = when {
             isPaste -> CommitTrigger.Paste
             else -> classifyTextChange(newTextFieldValue)
@@ -2083,6 +2086,9 @@ public class RichTextState internal constructor(
 
         try {
             onTextFieldValueChangeInner(newTextFieldValue, isPaste, pendingHtml)
+            if (replacedStyles != null) {
+                applyReplacedSelectionStyles(replacedStyles)
+            }
         } finally {
             if (trigger != null) finishHistoryRecord(trigger, before)
             if (
@@ -2123,6 +2129,77 @@ public class RichTextState internal constructor(
 
     private fun String.normalizeNewlines(): String =
         replace("\r\n", "\n").replace('\r', '\n')
+
+    /**
+     * The styles at the start of a non-collapsed selection an edit is about to replace,
+     * captured before the tree mutates so the inserted text can inherit them (the platform
+     * typing-attributes convention) instead of the style before the caret.
+     */
+    private class ReplacedSelectionStyles(
+        val insertedRange: TextRange,
+        val spanStyle: SpanStyle,
+        val richSpanStyle: RichSpanStyle,
+    )
+
+    @OptIn(ExperimentalRichTextApi::class)
+    private fun captureReplacedSelectionStyles(
+        old: TextFieldValue,
+        new: TextFieldValue,
+    ): ReplacedSelectionStyles? {
+        if (new.text == old.text) return null
+        val selMin = old.selection.min
+        val selMax = old.selection.max
+        if (selMin == selMax) return null
+        val insertedLength = new.text.length - (old.text.length - (selMax - selMin))
+        if (insertedLength <= 0 || selMin + insertedLength > new.text.length) return null
+        if (!new.text.regionMatches(0, old.text, 0, selMin)) return null
+        if (!new.text.regionMatches(selMin + insertedLength, old.text, selMax, old.text.length - selMax)) return null
+
+        val selectionStartSpan = getRichSpanByTextIndex(selMin, true) ?: return null
+        return ReplacedSelectionStyles(
+            insertedRange = TextRange(selMin, selMin + insertedLength),
+            spanStyle = selectionStartSpan.fullSpanStyle,
+            richSpanStyle = selectionStartSpan.fullStyle,
+        )
+    }
+
+    /**
+     * Restyles the text that replaced a selection to the captured selection-start styles.
+     * Runs inside the surrounding history record, so the edit stays a single undo entry.
+     * Rich span styles are only inherited when they accept edge text and are not atomic,
+     * so replacing a whole link or image never linkifies or atomizes the typed text.
+     */
+    @OptIn(ExperimentalRichTextApi::class)
+    private fun applyReplacedSelectionStyles(replaced: ReplacedSelectionStyles) {
+        val range = replaced.insertedRange
+        val insertedSpan = getRichSpanByTextIndex(range.min, true) ?: return
+        val currentSpanStyle = insertedSpan.fullSpanStyle
+        val currentRichSpanStyle = insertedSpan.fullStyle
+
+        val inheritRich = replaced.richSpanStyle.acceptsNewTextAtEdges && !replaced.richSpanStyle.isAtomic
+        val spanDiffers = currentSpanStyle != replaced.spanStyle
+        val richDiffers = inheritRich && currentRichSpanStyle != replaced.richSpanStyle
+        if (!spanDiffers && !richDiffers) return
+
+        val wasSuppressed = suppressHistoryRecording
+        suppressHistoryRecording = true
+        val oldToAddRichSpanStyle = toAddRichSpanStyle
+        val oldToRemoveRichSpanStyleKClass = toRemoveRichSpanStyleKClass
+        try {
+            if (spanDiffers) {
+                if (currentSpanStyle != SpanStyle()) removeSpanStyle(currentSpanStyle, range)
+                if (replaced.spanStyle != SpanStyle()) addSpanStyle(replaced.spanStyle, range)
+            }
+            if (richDiffers) {
+                if (currentRichSpanStyle !is RichSpanStyle.Default) removeRichSpan(currentRichSpanStyle, range)
+                if (replaced.richSpanStyle !is RichSpanStyle.Default) addRichSpan(replaced.richSpanStyle, range)
+            }
+        } finally {
+            toAddRichSpanStyle = oldToAddRichSpanStyle
+            toRemoveRichSpanStyleKClass = oldToRemoveRichSpanStyleKClass
+            suppressHistoryRecording = wasSuppressed
+        }
+    }
 
     private fun onTextFieldValueChangeInner(
         newTextFieldValue: TextFieldValue,

--- a/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextReplaceSelectionInheritanceTest.kt
+++ b/richeditor-compose/src/commonTest/kotlin/com/mohamedrejeb/richeditor/model/RichTextReplaceSelectionInheritanceTest.kt
@@ -1,0 +1,118 @@
+package com.mohamedrejeb.richeditor.model
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.document.FontRunStyle
+import com.mohamedrejeb.richeditor.document.RichTextSpanMark
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Typing or pasting over a non-collapsed selection styles the inserted text from the
+ * replaced range's start (the platform typing-attributes convention), not from the
+ * character before the caret, and the restyle is part of the same edit so undo/redo
+ * see a single entry.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+class RichTextReplaceSelectionInheritanceTest {
+
+    private val redArgb = 0xFFFF0000L
+
+    private fun stateWithRedWorld(): RichTextState {
+        val state = RichTextState()
+        state.setText("Hello world")
+        state.addSpanStyle(SpanStyle(color = Color(redArgb.toInt())), TextRange(6, 11))
+        return state
+    }
+
+    @Test
+    fun `typing over a colored selection inherits the replaced color`() {
+        val state = stateWithRedWorld()
+        state.selection = TextRange(6, 11)
+
+        state.onTextFieldValueChange(TextFieldValue("Hello X", selection = TextRange(7)))
+
+        assertEquals("Hello X", state.toText())
+        assertTrue(
+            state.toRichTextDocument().blocks.single().spans
+                .any { it is RichTextSpanMark.TextColor && it.range == 6..6 && it.argb == redArgb },
+        )
+    }
+
+    @Test
+    fun `typing over a selection does not inherit the style before the caret`() {
+        val state = RichTextState()
+        state.setText("Hello world")
+        state.addSpanStyle(SpanStyle(fontWeight = FontWeight.Bold), TextRange(0, 6))
+        state.selection = TextRange(6, 11)
+
+        state.onTextFieldValueChange(TextFieldValue("Hello X", selection = TextRange(7)))
+
+        assertEquals("Hello X", state.toText())
+        assertTrue(
+            state.toRichTextDocument().blocks.single().spans
+                .none { it is RichTextSpanMark.Bold && 6 in it.range },
+        )
+    }
+
+    @Test
+    fun `replacement styling is a single undo entry`() {
+        val state = stateWithRedWorld()
+        val before = state.toRichTextDocument()
+        state.selection = TextRange(6, 11)
+
+        state.onTextFieldValueChange(TextFieldValue("Hello X", selection = TextRange(7)))
+
+        state.history.undo()
+        assertEquals(before, state.toRichTextDocument())
+    }
+
+    @Test
+    fun `custom rich span style is inherited when replacing its text`() {
+        val state = RichTextState()
+        state.setText("Hello world")
+        state.addRichSpan(FontRunStyle(slug = "amiri"), TextRange(6, 11))
+        state.selection = TextRange(6, 11)
+
+        state.onTextFieldValueChange(TextFieldValue("Hello X", selection = TextRange(7)))
+
+        assertTrue(
+            state.toRichTextDocument().blocks.single().spans
+                .any { it is RichTextSpanMark.Custom && it.range == 6..6 && it.style == FontRunStyle(slug = "amiri") },
+        )
+    }
+
+    @Test
+    fun `link is not inherited when replacing the whole link`() {
+        val state = RichTextState()
+        state.setText("Hello world")
+        state.addRichSpan(RichSpanStyle.Link(url = "https://example.com"), TextRange(6, 11))
+        state.selection = TextRange(6, 11)
+
+        state.onTextFieldValueChange(TextFieldValue("Hello X", selection = TextRange(7)))
+
+        assertTrue(
+            state.toRichTextDocument().blocks.single().spans
+                .none { it is RichTextSpanMark.Link },
+        )
+    }
+
+    @Test
+    fun `plain paste over a styled selection inherits the replaced style`() {
+        val state = stateWithRedWorld()
+        state.selection = TextRange(6, 11)
+
+        state.onTextFieldValueChange(TextFieldValue("Hello pasted", selection = TextRange(12)))
+
+        assertEquals("Hello pasted", state.toText())
+        assertTrue(
+            state.toRichTextDocument().blocks.single().spans
+                .any { it is RichTextSpanMark.TextColor && it.range == 6..11 && it.argb == redArgb },
+        )
+    }
+}


### PR DESCRIPTION
Captures the SpanStyle and RichSpanStyle at the selection start before the edit mutates the tree and restyles the inserted text inside the same history record, so the replacement is one undo entry. Rich span styles inherit only when they accept edge text and are not atomic, so replacing a whole link or image keeps the typed text plain.