### PR TITLE
Prepare 1.2.0: fix json module build on AGP 9, bump version references

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Deploy snapshot
         env:
-          VERSION: 1.1.0-SNAPSHOT
+          VERSION: 1.2.0-SNAPSHOT
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <h1 align="center">Compose Rich Editor</h1><br>
 
-[![Kotlin](https://img.shields.io/badge/kotlin-2.4.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.4.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Compose](https://img.shields.io/badge/compose-1.11.1-blue.svg?logo=jetpackcompose)](https://www.jetbrains.com/lp/compose-multiplatform)
 [![MohamedRejeb](https://raw.githubusercontent.com/MohamedRejeb/MohamedRejeb/main/badges/mohamedrejeb.svg)](https://github.com/MohamedRejeb)
 [![Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 [![API](https://img.shields.io/badge/API-23%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=23)
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.0.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.1.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
 
 ![Compose Rich Editor](docs/images/logo-large-light.svg#gh-light-mode-only)
 ![Compose Rich Editor](docs/images/logo-large-dark.svg#gh-dark-mode-only)
@@ -34,20 +34,21 @@ A rich text editor library for both Jetpack Compose and Compose Multiplatform, f
 
 ## Download
 
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.0.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.1.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
 
 Compose Rich Editor is available on `mavenCentral()`.
 
 ```kotlin
-implementation("com.mohamedrejeb.richeditor:richeditor-compose:1.0.0")
+implementation("com.mohamedrejeb.richeditor:richeditor-compose:1.1.0")
 ```
 
 ## Compatibility
 
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.0.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.1.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
 
 | Kotlin version | Compose version | Compose Rich Editor version |
 |----------------|-----------------|-----------------------------|
+| 2.4.10         | 1.11.1          | 1.1.0                       |
 | 2.4.0          | 1.11.1          | 1.0.0                       |
 | 2.3.21         | 1.10.3          | 1.0.0-rc14                  |
 | 2.1.21         | 1.8.2           | 1.0.0-rc13                  |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
 Use the snapshot version:
 
 ```kotlin
-implementation("com.mohamedrejeb.richeditor:richeditor-compose:1.0.0-SNAPSHOT")
+implementation("com.mohamedrejeb.richeditor:richeditor-compose:1.2.0-SNAPSHOT")
 ```
 
 ⚠️ **Warning**: Snapshots are deployed for each new commit on `main` that passes CI. They can potentially contain breaking changes or may be unstable. Use at your own risk.

--- a/docs/images.md
+++ b/docs/images.md
@@ -28,7 +28,7 @@ The `richeditor-compose-coil3` artifact ships a drop-in `Coil3ImageLoader` that
 uses Coil's `rememberAsyncImagePainter`:
 
 ```kotlin
-implementation("com.mohamedrejeb.richeditor:richeditor-compose-coil3:1.0.0")
+implementation("com.mohamedrejeb.richeditor:richeditor-compose-coil3:1.1.0")
 ```
 
 Provide it via `CompositionLocalProvider`, usually at the root of your editor

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
-[![Kotlin](https://img.shields.io/badge/kotlin-2.4.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.4.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Compose](https://img.shields.io/badge/compose-1.11.1-blue.svg?logo=jetpackcompose)](https://www.jetbrains.com/lp/compose-multiplatform)
 [![MohamedRejeb](https://raw.githubusercontent.com/MohamedRejeb/MohamedRejeb/main/badges/mohamedrejeb.svg)](https://github.com/MohamedRejeb)
 [![Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 [![API](https://img.shields.io/badge/API-23%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=23)
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.0.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.1.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
 
 ![Compose Rich Editor](images/logo-large-light.svg#only-light)
 ![Compose Rich Editor](images/logo-large-dark.svg#only-dark)
@@ -27,20 +27,21 @@ A rich text editor library for both Jetpack Compose and Compose Multiplatform, f
 
 ## Download
 
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.0.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.1.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
 
 Compose Rich Editor is available on `mavenCentral()`.
 
 ```kotlin
-implementation("com.mohamedrejeb.richeditor:richeditor-compose:1.0.0")
+implementation("com.mohamedrejeb.richeditor:richeditor-compose:1.1.0")
 ```
 
 ## Compatibility
 
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.0.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-1.1.0-blue)](https://search.maven.org/search?q=g:%22com.mohamedrejeb.richeditor%22%20AND%20a:%22richeditor-compose%22)
 
 | Kotlin version | Compose version | Compose Rich Editor version |
 |----------------|-----------------|-----------------------------|
+| 2.4.10         | 1.11.1          | 1.1.0                       |
 | 2.4.0          | 1.11.1          | 1.0.0                       |
 | 2.3.21         | 1.10.3          | 1.0.0-rc14                  |
 | 2.1.21         | 1.8.2           | 1.0.0-rc13                  |
@@ -203,7 +204,7 @@ See [Headings](headings.md) for details.
 Inline images render through a pluggable `ImageLoader`. For network images, drop in the Coil3 integration:
 
 ```kotlin
-implementation("com.mohamedrejeb.richeditor:richeditor-compose-coil3:1.0.0")
+implementation("com.mohamedrejeb.richeditor:richeditor-compose-coil3:1.1.0")
 ```
 
 ```kotlin

--- a/docs/json_import_export.md
+++ b/docs/json_import_export.md
@@ -6,7 +6,7 @@ The `richeditor-compose-json` module serializes editor content to a stable, vers
 
 ```kotlin
 dependencies {
-    implementation("com.mohamedrejeb.richeditor:richeditor-compose-json:1.0.0")
+    implementation("com.mohamedrejeb.richeditor:richeditor-compose-json:1.1.0")
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ dokka = "2.2.0"
 
 ksoup = "0.6.0"
 jetbrainsMarkdown = "0.7.9"
-coil = "3.5.0"
+coil = "3.6.0"
 kotlinx-serialization = "1.11.0"
 
 vanniktech-maven-publish = "0.37.0"

--- a/richeditor-compose-json/build.gradle.kts
+++ b/richeditor-compose-json/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.androidKotlinMultiplatformLibrary)
     alias(libs.plugins.bcv)
     id("module.publication")
 }
@@ -17,8 +17,13 @@ kotlin {
     explicitApi()
     applyDefaultHierarchyTemplate()
 
-    androidTarget {
-        publishLibraryVariants("release")
+    android {
+        namespace = "com.mohamedrejeb.richeditor.json"
+        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
+
+        withHostTestBuilder {}
+
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
@@ -38,6 +43,7 @@ kotlin {
                 enabled = false
             }
         }
+        binaries.executable()
     }
 
     wasmJs {
@@ -46,6 +52,7 @@ kotlin {
                 enabled = true
             }
         }
+        binaries.executable()
     }
 
     iosArm64()
@@ -61,20 +68,6 @@ kotlin {
 
     sourceSets.commonTest.dependencies {
         implementation(kotlin("test"))
-    }
-}
-
-android {
-    namespace = "com.mohamedrejeb.richeditor.json"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-
-    defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 


### PR DESCRIPTION
## Summary

Main's CI has been red since the Compose 1.12 merge (PR #785): the parallel-merged `richeditor-compose-json` module still used the removed `androidLibrary` catalog alias and the legacy Android DSL. This PR fixes the build and prepares the 1.2.0 release.

- fix: migrate `richeditor-compose-json/build.gradle.kts` to `androidKotlinMultiplatformLibrary` with the new `kotlin { android { } }` DSL (mirrors `richeditor-compose-coil3`), and add the `binaries.executable()` web declarations the module missed from the CMP-4906 fix
- docs: reference 1.1.0 as the latest version (README + docs badges, dependency snippets incl. json and coil3 artifacts, compatibility table row for Kotlin 2.4.10 / CMP 1.11.1 / 1.1.0)
- chore: bump snapshot version to 1.2.0-SNAPSHOT (workflow + FAQ), since main now targets Compose 1.12

## Test plan

- [x] `:richeditor-compose-json:desktopTest`, `:richeditor-compose-json:apiCheck`, `:richeditor-compose-json:compileTestKotlinWasmJs` pass locally
- [x] CI green on this PR (`apiCheck` ubuntu + `allTests` macOS), which restores main's red pipeline